### PR TITLE
fix: サイドメニュー表示時の背景色を設定

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -191,6 +191,7 @@ h1, h2, h3, .font-serif {
 #mobile-menu {
     transform: translateX(100%);
     transition: transform 0.4s ease;
+    background-color: #000;
 }
 #mobile-menu.open {
     transform: translateX(0);


### PR DESCRIPTION
サイドメニューを開いたときに、後ろのコンテンツが透けてしまっていたので、背景色を設定しました。