### PR TITLE
Add season rules guide pages

### DIFF
--- a/config/season_rule_pages.json
+++ b/config/season_rule_pages.json
@@ -1,0 +1,96 @@
+{
+  "current_slug": "s1",
+  "pages": [
+    {
+      "slug": "s2",
+      "season_label": "Season 02",
+      "title": "シーズン2制度ガイド",
+      "description": "ポーカー鳳凰戦シーズン2の仮条件ページです。昇格・降格・認定条件の表示イメージを確認できます。",
+      "period_label": "2026.04.13 - 2026.06.01",
+      "hero_image": "images/jopt_season1.jpg",
+      "thumbnail_image": "images/jopt_season1.jpg",
+      "summary": "シーズン2の仮データです。規定ハンド数は400ハンドを維持し、Bリーグは上下25%、Cリーグは上位40%を基準にリーグ変更を行う想定です。",
+      "overview": "シーズン2では、規定ハンド数400ハンドを維持したまま、各リーグの昇格・降格条件をより明確に設定します。\nBリーグは上位・下位それぞれ25%をリーグ変更対象とし、上位6名はAリーグ昇格圏となります。\nCリーグは上位40%をリーグ変更対象とし、次シーズンのBリーグ昇格を目指す構造です。\nシーズン1よりも、各リーグで「どこを目指せばよいか」が分かりやすい制度へ整理したシーズンです。",
+      "promotion_heading": "昇格条件（B・Cリーグ）",
+      "relegation_heading": "降格条件（Bリーグ）",
+      "promotion_blocks": [
+        {
+          "title": "BリーグからAリーグへ昇格",
+          "accent": "上位25% / 上位6名がAリーグへ昇格"
+        },
+        {
+          "title": "CリーグからBリーグへ昇格",
+          "accent": "上位40% / 想定22名がBリーグへ昇格"
+        }
+      ],
+      "relegation_blocks": [
+        {
+          "title": "Bリーグ下位帯の扱い",
+          "accent": "下位25% / 下位6名がリーグ変更対象"
+        }
+      ],
+      "extra_rules": [
+        {
+          "title": "参加要件未達成時の扱い",
+          "body": "規定ハンド数は400ハンドです。シーズン終了時点で400ハンドに満たない場合、そのシーズンの公式記録は認定対象外となり、次シーズンの所属リーグ判定に影響します。"
+        }
+      ],
+      "schedule": [
+        { "week_label": "第1週", "date_label": "2026/04/13", "time_label": "20:00 - 23:00" },
+        { "week_label": "第2週", "date_label": "2026/04/20", "time_label": "20:00 - 23:00" },
+        { "week_label": "第3週", "date_label": "2026/04/27", "time_label": "20:00 - 23:00" },
+        { "week_label": "第4週", "date_label": "2026/05/04", "time_label": "20:00 - 23:00" },
+        { "week_label": "第5週", "date_label": "2026/05/11", "time_label": "20:00 - 23:00" },
+        { "week_label": "第6週", "date_label": "2026/05/18", "time_label": "20:00 - 23:00" },
+        { "week_label": "第7週", "date_label": "2026/05/25", "time_label": "20:00 - 23:00" },
+        { "week_label": "第8週", "date_label": "2026/06/01", "time_label": "20:00 - 23:00" }
+      ],
+      "diagram_image": "images/jopt_season1.jpg",
+      "diagram_caption": "シーズン2制度の仮プレビュー",
+      "stats_link": "season_stats.html"
+    },
+    {
+      "slug": "s1",
+      "season_label": "Season 01",
+      "title": "シーズン1制度ガイド",
+      "description": "ポーカー鳳凰戦シーズン1の昇格・降格・認定条件をまとめた制度ガイドです。",
+      "period_label": "2026.02.02 - 2026.03.30",
+      "hero_image": "images/houoh_season.png",
+      "thumbnail_image": "images/houoh_season.png",
+      "summary": "鳳凰戦最初のシーズン。全員がCリーグから出発し、シーズン終了時の成績と参加要件をもとに次シーズンの所属リーグを決定します。",
+      "overview": "シーズン1では、全参加者がCリーグからスタートします。評価は短期的な勝敗ではなく、シーズンを通じた累計収支と試行回数を前提に行い、次シーズンの所属リーグへ反映します。",
+      "promotion_blocks": [
+        {
+          "title": "CリーグからBリーグへ昇格",
+          "accent": "上位40%が次シーズンでBリーグへ昇格"
+        }
+      ],
+      "relegation_blocks": [
+        {
+          "title": "初回シーズンの基本扱い",
+          "accent": "昇格圏外はCリーグ継続"
+        }
+      ],
+      "extra_rules": [
+        {
+          "title": "参加要件未達成時の扱い",
+          "body": "規定ハンド数は400ハンドです。シーズン終了時点で400ハンドに満たない場合、そのシーズンの公式記録は認定されず、次シーズンの所属ランクは1ランク降格扱いとなります。"
+        }
+      ],
+      "schedule": [
+        { "week_label": "第0週", "date_label": "2026/02/02", "time_label": "20:00 - 23:00" },
+        { "week_label": "第1週", "date_label": "2026/02/09", "time_label": "20:00 - 23:00" },
+        { "week_label": "第2週", "date_label": "2026/02/16", "time_label": "20:00 - 23:00" },
+        { "week_label": "第3週", "date_label": "2026/02/23", "time_label": "20:00 - 23:00" },
+        { "week_label": "第4週", "date_label": "2026/03/02", "time_label": "20:00 - 23:00" },
+        { "week_label": "第5週", "date_label": "2026/03/09", "time_label": "20:00 - 23:00" },
+        { "week_label": "第6週", "date_label": "2026/03/16", "time_label": "20:00 - 23:00" },
+        { "week_label": "第7週", "date_label": "2026/03/23", "time_label": "20:00 - 23:00" },
+        { "week_label": "第8週", "date_label": "2026/03/30", "time_label": "20:00 - 23:00" }
+      ],
+      "diagram_image": "images/houoh_season.png",
+      "diagram_caption": "シーズン1のリーグ制度イメージ",
+      "stats_link": "season_stats.html"
+    }
+  ]
+}

--- a/config/season_rule_pages.json
+++ b/config/season_rule_pages.json
@@ -4,29 +4,29 @@
     {
       "slug": "s2",
       "season_label": "Season 02",
-      "title": "シーズン2制度ガイド",
-      "description": "ポーカー鳳凰戦シーズン2の仮条件ページです。昇格・降格・認定条件の表示イメージを確認できます。",
+      "title": "シーズン2条件",
+      "description": "",
       "period_label": "2026.04.13 - 2026.06.01",
       "hero_image": "images/jopt_season1.jpg",
-      "thumbnail_image": "images/jopt_season1.jpg",
-      "summary": "シーズン2の仮データです。規定ハンド数は400ハンドを維持し、Bリーグは上下25%、Cリーグは上位40%を基準にリーグ変更を行う想定です。",
-      "overview": "シーズン2では、規定ハンド数400ハンドを維持したまま、各リーグの昇格・降格条件をより明確に設定します。\nBリーグは上位・下位それぞれ25%をリーグ変更対象とし、上位6名はAリーグ昇格圏となります。\nCリーグは上位40%をリーグ変更対象とし、次シーズンのBリーグ昇格を目指す構造です。\nシーズン1よりも、各リーグで「どこを目指せばよいか」が分かりやすい制度へ整理したシーズンです。",
+      "thumbnail_image": "images/season2-guide.png",
+      "summary": "規定ハンド数は400ハンドを維持し、Bリーグは上下25%、Cリーグは上位40%を基準にリーグ変更を行う想定です。",
+      "overview": "シーズン2では、規定ハンド数400ハンドを維持したまま、各リーグの昇格・降格条件をより明確に設定します。\nBリーグは上位・下位それぞれ25%をリーグ変更対象とし、Aリーグ昇格とCリーグ降格の判定を行います。\nCリーグは上位40%をリーグ変更対象とし、次シーズンのBリーグ昇格を目指す構造です。\nシーズン1よりも、各リーグで「どこを目指せばよいか」が分かりやすい制度へ整理したシーズンです。",
       "promotion_heading": "昇格条件（B・Cリーグ）",
       "relegation_heading": "降格条件（Bリーグ）",
       "promotion_blocks": [
         {
           "title": "BリーグからAリーグへ昇格",
-          "accent": "上位25% / 上位6名がAリーグへ昇格"
+          "accent": "上位25% / Aリーグへ昇格"
         },
         {
           "title": "CリーグからBリーグへ昇格",
-          "accent": "上位40% / 想定22名がBリーグへ昇格"
+          "accent": "上位40% / Bリーグへ昇格"
         }
       ],
       "relegation_blocks": [
         {
           "title": "Bリーグ下位帯の扱い",
-          "accent": "下位25% / 下位6名がリーグ変更対象"
+          "accent": "下位25% / Cリーグへ降格"
         }
       ],
       "extra_rules": [
@@ -45,15 +45,15 @@
         { "week_label": "第7週", "date_label": "2026/05/25", "time_label": "20:00 - 23:00" },
         { "week_label": "第8週", "date_label": "2026/06/01", "time_label": "20:00 - 23:00" }
       ],
-      "diagram_image": "images/jopt_season1.jpg",
-      "diagram_caption": "シーズン2制度の仮プレビュー",
+      "diagram_image": "images/season2-guide.png",
+      "diagram_caption": "",
       "stats_link": "season_stats.html"
     },
     {
       "slug": "s1",
       "season_label": "Season 01",
-      "title": "シーズン1制度ガイド",
-      "description": "ポーカー鳳凰戦シーズン1の昇格・降格・認定条件をまとめた制度ガイドです。",
+      "title": "シーズン1条件",
+      "description": "ポーカー鳳凰戦シーズン1の昇格・降格・認定条件をまとめたページです。",
       "period_label": "2026.02.02 - 2026.03.30",
       "hero_image": "images/houoh_season.png",
       "thumbnail_image": "images/houoh_season.png",
@@ -90,6 +90,11 @@
       ],
       "diagram_image": "images/houoh_season.png",
       "diagram_caption": "シーズン1のリーグ制度イメージ",
+      "sponsorship": {
+        "image": "images/jopt_season1.jpg",
+        "alt": "JOPT協賛決定 鳳凰戦 Season 1 Cリーグ賞品",
+        "href": "sponsor.html"
+      },
       "stats_link": "season_stats.html"
     }
   ]

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
                             今季の制度を見る <i class="fas fa-arrow-right"></i>
                         </a>
                         <a href="season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
-                            制度一覧へ
+                            シーズン条件一覧へ
                         </a>
                     </div>
                 </div>
@@ -416,7 +416,7 @@
                     <div class="bg-white/5 border border-white/10 p-4 inline-block">
                         <p class="text-[11px] text-gray-400 leading-relaxed">
                             <i class="fas fa-circle-info mr-2 text-gold"></i>
-                            今シーズンの条件確認は個別ページから、全体の見取り図は制度一覧ページから確認できます。
+                            今シーズンの条件確認は個別ページから、全体の見取り図はシーズン条件一覧ページから確認できます。
                         </p>
                     </div>
                     <div class="flex flex-col sm:flex-row justify-center gap-3 pt-2">
@@ -424,7 +424,7 @@
                             今季の制度ページ <i class="fas fa-arrow-right"></i>
                         </a>
                         <a href="season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
-                            制度一覧を見る
+                            シーズン条件一覧を見る
                         </a>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -116,17 +116,19 @@
                 
                 <div class="bg-white/5 p-6 border-l-4 border-white/20 rounded-r-sm flex flex-col justify-center">
                     <h4 class="text-white font-serif font-black text-lg mb-3 flex items-center gap-3">
-                        <i class="fas fa-trophy text-gold text-sm"></i> 昇格条件
+                        <i class="fas fa-book-open text-gold text-sm"></i> シーズン制度ページ
                     </h4>
-                    <div class="space-y-3">
-                        <div class="flex justify-between items-center border-b border-white/5 pb-2">
-                            <span class="text-xs text-gray-500 font-bold">上位 40%</span>
-                            <span class="text-gold font-black text-xs tracking-widest uppercase">Bリーグへ昇格</span>
-                        </div>
-                        <div class="flex justify-between items-center border-b border-white/5 pb-2">
-                            <span class="text-xs text-gray-500 font-bold">下位 60%</span>
-                            <span class="text-white/40 font-black text-xs tracking-widest uppercase">Cリーグ継続</span>
-                        </div>
+                    <p class="text-sm text-gray-400 leading-loose mb-5">
+                        昇格・降格・認定条件はシーズンごとに更新されます。
+                        最新制度と過去シーズンの条件差分は、専用の制度ページで確認できます。
+                    </p>
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <a href="season-rules-s1.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                            今季の制度を見る <i class="fas fa-arrow-right"></i>
+                        </a>
+                        <a href="season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                            制度一覧へ
+                        </a>
                     </div>
                 </div>
             </div>
@@ -404,17 +406,26 @@
 
             <!-- Certification Section -->
             <div class="mt-16 reveal bg-gradient-to-r from-transparent via-white/5 to-transparent p-8 text-center border-y border-white/5 delay-300">
-                <h4 class="text-white font-serif font-bold text-sm mb-4 tracking-widest text-gold uppercase italic">リーグ認定基準</h4>
+                <h4 class="text-white font-serif font-bold text-sm mb-4 tracking-widest text-gold uppercase italic">制度確認ガイド</h4>
                 <div class="max-w-3xl mx-auto space-y-4">
                     <p class="text-xs md:text-sm text-gray-300 leading-loose">
-                        各プレイヤーはシーズン中に <span class="text-white font-bold border-b border-gold/50">400ハンド以上の対戦</span> が義務付けられます。
+                        参加要件、昇格・降格条件、公式記録の認定基準は
+                        <span class="text-white font-bold border-b border-gold/50">シーズンごとに定義された制度ページ</span>
+                        を正本として案内します。
                     </p>
-                    <div class="bg-red-950/20 border border-red-900/30 p-4 inline-block">
-                        <p class="text-[11px] text-red-400 leading-relaxed">
-                            <i class="fas fa-exclamation-circle mr-2"></i>
-                            ハンド数が400に満たない場合、そのシーズンの公式記録は認められず、<br class="hidden md:block">
-                            <span class="text-white font-bold underline underline-offset-4 decoration-red-900">次シーズンの所属ランクは「1ランク降格」となります。</span>
+                    <div class="bg-white/5 border border-white/10 p-4 inline-block">
+                        <p class="text-[11px] text-gray-400 leading-relaxed">
+                            <i class="fas fa-circle-info mr-2 text-gold"></i>
+                            今シーズンの条件確認は個別ページから、全体の見取り図は制度一覧ページから確認できます。
                         </p>
+                    </div>
+                    <div class="flex flex-col sm:flex-row justify-center gap-3 pt-2">
+                        <a href="season-rules-s1.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                            今季の制度ページ <i class="fas fa-arrow-right"></i>
+                        </a>
+                        <a href="season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                            制度一覧を見る
+                        </a>
                     </div>
                 </div>
             </div>

--- a/js/header.js
+++ b/js/header.js
@@ -3,6 +3,7 @@
     const NAV_ITEMS = [
         { label: 'トップ', href: 'index.html' },
         { label: 'ランキング', href: 'season_stats.html' },
+        { label: 'シーズン制度', href: 'season-rules.html' },
         { label: '注目選手', href: 'pickup.html' },
         { label: '協賛一覧', href: 'sponsor.html' },
     ];

--- a/js/season-rules.js
+++ b/js/season-rules.js
@@ -1,0 +1,458 @@
+(function () {
+    const CONFIG_PATH = 'config/season_rule_pages.json';
+
+    function escapeHtml(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function textToHtml(value) {
+        return escapeHtml(value).replace(/\n/g, '<br>');
+    }
+
+    function detailUrl(slug) {
+        return `season-rules-${slug}.html`;
+    }
+
+    function imageTag(src, alt, className) {
+        return `<img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" class="${className}" onerror="this.src='https://images.unsplash.com/photo-1518893063132-36e46dbe2428?auto=format&fit=crop&q=80&w=1200'">`;
+    }
+
+    function loadingMarkup() {
+        return `
+            <div class="py-16 text-center text-gray-500">
+                <i class="fas fa-spinner fa-spin text-2xl mb-4 block text-gold/60"></i>
+                読み込み中です...
+            </div>
+        `;
+    }
+
+    function errorMarkup(message) {
+        return `
+            <div class="jp-card p-8 md:p-10 corner-deco text-center">
+                <i class="fas fa-exclamation-triangle text-2xl text-gold mb-4"></i>
+                <p class="text-sm text-gray-300 leading-loose">${textToHtml(message)}</p>
+            </div>
+        `;
+    }
+
+    function renderBlockList(blocks, emptyMessage, iconClass, accentClass) {
+        if (!Array.isArray(blocks) || blocks.length === 0) {
+            return `
+                <div class="jp-card p-6 border border-white/10">
+                    <p class="text-sm text-gray-400 leading-loose">${escapeHtml(emptyMessage)}</p>
+                </div>
+            `;
+        }
+
+        return blocks.map((block) => {
+            const items = Array.isArray(block.items) && block.items.length > 0
+                ? `
+                    <ul class="space-y-2 text-sm text-gray-400 leading-loose">
+                        ${block.items.map((item) => `
+                            <li class="flex gap-3">
+                                <span class="text-gold mt-1"><i class="fas fa-minus"></i></span>
+                                <span>${escapeHtml(item)}</span>
+                            </li>
+                        `).join('')}
+                    </ul>
+                `
+                : '';
+
+            return `
+                <article class="jp-card p-7 md:p-8 corner-deco h-full">
+                    <div class="flex items-start justify-between gap-4 mb-5">
+                        <div>
+                            <div class="text-[10px] font-black tracking-[0.45em] uppercase text-gold/70 mb-2">Rule Block</div>
+                            <h3 class="text-xl md:text-2xl font-serif font-black text-white leading-snug">${escapeHtml(block.title)}</h3>
+                        </div>
+                        <div class="w-11 h-11 shrink-0 rounded-full border border-white/10 bg-white/5 flex items-center justify-center text-gold">
+                            <i class="${escapeHtml(iconClass)}"></i>
+                        </div>
+                    </div>
+                    ${block.accent ? `<div class="inline-flex items-center px-4 py-3 mb-4 border ${accentClass} text-xl md:text-2xl font-black leading-snug">${escapeHtml(block.accent)}</div>` : ''}
+                    ${block.body ? `<p class="text-sm text-gray-300 leading-loose mb-5">${textToHtml(block.body)}</p>` : ''}
+                    ${items}
+                </article>
+            `;
+        }).join('');
+    }
+
+    function renderRelatedLinkCard(options) {
+        const {
+            eyebrow,
+            title,
+            description,
+            href,
+            iconClass,
+            muted
+        } = options;
+
+        const baseClass = muted
+            ? 'block border border-white/5 bg-white/[0.03] px-5 py-5 rounded-sm opacity-55'
+            : 'block border border-white/10 bg-white/5 px-5 py-5 rounded-sm hover:border-gold/40 transition-all duration-300';
+
+        const content = `
+            <div class="text-[10px] font-black tracking-[0.35em] uppercase text-white/35 mb-2">${escapeHtml(eyebrow)}</div>
+            <div class="flex items-start justify-between gap-4 mb-3">
+                <div class="text-lg font-serif font-bold text-white">${escapeHtml(title)}</div>
+                <i class="${escapeHtml(iconClass)} text-gold/70 mt-1"></i>
+            </div>
+            <p class="text-sm text-gray-400 leading-loose">${escapeHtml(description)}</p>
+        `;
+
+        if (muted || !href) {
+            return `<div class="${baseClass}">${content}</div>`;
+        }
+
+        return `<a href="${escapeHtml(href)}" class="${baseClass}">${content}</a>`;
+    }
+
+    function renderScheduleTable(page) {
+        const schedule = Array.isArray(page.schedule) ? page.schedule : [];
+
+        if (schedule.length === 0) {
+            return errorMarkup('このシーズンのスケジュールはまだ設定されていません。');
+        }
+
+        return `
+            <div class="jp-card p-5 md:p-6 corner-deco">
+                <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3 mb-5">
+                    <div>
+                        <div class="text-[10px] font-black tracking-[0.35em] uppercase text-gold/60 mb-2">Season Period</div>
+                        <div class="text-lg md:text-xl font-serif font-bold text-white">${escapeHtml(page.period_label)}</div>
+                    </div>
+                    <div class="text-xs text-gray-500">毎週月曜開催予定</div>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="w-full min-w-[420px]">
+                        <thead>
+                            <tr class="border-b border-gold/20">
+                                <th class="py-3 px-3 text-left text-[11px] font-black tracking-[0.25em] uppercase text-gold">週</th>
+                                <th class="py-3 px-3 text-left text-[11px] font-black tracking-[0.25em] uppercase text-gold">開催日付</th>
+                                <th class="py-3 px-3 text-left text-[11px] font-black tracking-[0.25em] uppercase text-gold">開催時間</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            ${schedule.map((item) => `
+                                <tr>
+                                    <td class="py-3 px-3 text-base font-serif font-bold text-white whitespace-nowrap">${escapeHtml(item.week_label)}</td>
+                                    <td class="py-3 px-3 text-sm text-gray-300 whitespace-nowrap">${escapeHtml(item.date_label)}</td>
+                                    <td class="py-3 px-3 text-sm text-gray-400 whitespace-nowrap">${escapeHtml(item.time_label)}</td>
+                                </tr>
+                            `).join('')}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        `;
+    }
+
+    function renderCurrentFeature(page, isCurrent) {
+        return `
+            <article class="relative overflow-hidden rounded-sm border border-gold/30 bg-black">
+                <div class="absolute inset-0">
+                    ${imageTag(page.hero_image, page.title, 'w-full h-full object-cover opacity-25')}
+                    <div class="absolute inset-0 bg-gradient-to-r from-black via-black/85 to-black/50"></div>
+                    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(212,175,55,0.18),transparent_40%)]"></div>
+                </div>
+                <div class="relative z-10 px-6 py-10 md:px-10 md:py-14">
+                    <div class="inline-flex flex-wrap gap-3 items-center mb-6">
+                        <span class="border border-gold/30 px-3 py-1 text-[10px] font-black tracking-[0.45em] uppercase text-gold">${escapeHtml(page.season_label)}</span>
+                        <span class="border border-white/10 px-3 py-1 text-[10px] font-black tracking-[0.35em] uppercase text-white/70">${escapeHtml(page.period_label)}</span>
+                        ${isCurrent ? '<span class="border border-green-500/30 bg-green-500/10 px-3 py-1 text-[10px] font-black tracking-[0.35em] uppercase text-green-300">Current</span>' : ''}
+                    </div>
+                    <div class="max-w-3xl">
+                        <h2 class="text-3xl md:text-5xl font-serif font-black text-white tracking-widest leading-tight mb-5">${escapeHtml(page.title)}</h2>
+                        <p class="text-sm md:text-base text-gray-300 leading-loose mb-8">${escapeHtml(page.summary)}</p>
+                        <div class="flex flex-col sm:flex-row gap-4">
+                            <a href="${detailUrl(page.slug)}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.3em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                                制度詳細を見る <i class="fas fa-arrow-right"></i>
+                            </a>
+                            <a href="${escapeHtml(page.stats_link || 'season_stats.html')}" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                                ランキングを見る <i class="fas fa-chart-line"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </article>
+        `;
+    }
+
+    function renderHub(config) {
+        const currentTarget = document.getElementById('season-rules-current');
+        const archiveTarget = document.getElementById('season-rules-grid');
+
+        if (!currentTarget || !archiveTarget) return;
+
+        const pages = Array.isArray(config.pages) ? config.pages : [];
+        const currentPage = pages.find((page) => page.slug === config.current_slug) || pages[0];
+
+        if (!currentPage) {
+            currentTarget.innerHTML = errorMarkup('制度ページの設定がまだありません。');
+            archiveTarget.innerHTML = '';
+            return;
+        }
+
+        currentTarget.innerHTML = renderCurrentFeature(currentPage, true);
+
+        const orderedPages = [
+            currentPage,
+            ...pages.filter((page) => page.slug !== currentPage.slug)
+        ];
+
+        archiveTarget.innerHTML = orderedPages.map((page) => `
+            <article class="group jp-card overflow-hidden h-full">
+                <a href="${detailUrl(page.slug)}" class="block h-full">
+                    <div class="relative aspect-[4/3] overflow-hidden border-b border-white/5">
+                        ${imageTag(page.thumbnail_image, page.title, 'w-full h-full object-cover opacity-80 group-hover:scale-105 transition duration-700')}
+                        <div class="absolute inset-0 bg-gradient-to-t from-black via-black/35 to-transparent"></div>
+                        <div class="absolute left-3 top-3 flex flex-wrap gap-2">
+                            <span class="border border-gold/30 bg-black/60 px-2 py-1 text-[9px] font-black tracking-[0.28em] uppercase text-gold">${escapeHtml(page.season_label)}</span>
+                            ${page.slug === config.current_slug ? '<span class="border border-green-500/30 bg-green-500/10 px-2 py-1 text-[9px] font-black tracking-[0.22em] uppercase text-green-300">Current</span>' : ''}
+                        </div>
+                    </div>
+                    <div class="p-4 md:p-5 flex flex-col gap-3">
+                        <div>
+                            <div class="text-[9px] font-black tracking-[0.32em] uppercase text-white/35 mb-2">${escapeHtml(page.period_label)}</div>
+                            <h3 class="text-lg md:text-xl font-serif font-black text-white leading-snug group-hover:text-gold transition-colors">${escapeHtml(page.title)}</h3>
+                        </div>
+                        <p class="text-xs text-gray-400 leading-relaxed">${escapeHtml(page.summary)}</p>
+                        <div class="pt-1 flex items-center justify-between text-[11px] font-black tracking-[0.2em] uppercase text-gold">
+                            <span>詳細を見る</span>
+                            <i class="fas fa-arrow-right transition-transform duration-300 group-hover:translate-x-1"></i>
+                        </div>
+                    </div>
+                </a>
+            </article>
+        `).join('');
+    }
+
+    function renderDetail(config, slug) {
+        const target = document.getElementById('season-rule-detail');
+        if (!target) return;
+
+        const pages = Array.isArray(config.pages) ? config.pages : [];
+        const pageIndex = pages.findIndex((item) => item.slug === slug);
+        const page = pageIndex >= 0 ? pages[pageIndex] : null;
+        if (!page) {
+            target.innerHTML = errorMarkup('指定されたシーズン制度ページが見つかりませんでした。');
+            return;
+        }
+
+        const previousSeasonPage = pageIndex >= 0 && pageIndex < pages.length - 1 ? pages[pageIndex + 1] : null;
+        const nextSeasonPage = pageIndex > 0 ? pages[pageIndex - 1] : null;
+
+        const promotionMarkup = renderBlockList(
+            page.promotion_blocks,
+            'このシーズンでは昇格条件の記載はありません。',
+            'fas fa-arrow-up',
+            'border-gold/40 bg-gold/10 text-gold'
+        );
+
+        const relegationMarkup = renderBlockList(
+            page.relegation_blocks,
+            'このシーズンでは降格条件の記載はありません。',
+            'fas fa-arrow-down',
+            'border-red-900/40 bg-red-950/30 text-red-300'
+        );
+
+        const extraRuleMarkup = Array.isArray(page.extra_rules) && page.extra_rules.length > 0
+            ? page.extra_rules.map((rule) => `
+                <article class="border border-white/10 bg-white/5 px-5 py-5 rounded-sm">
+                    <div class="text-[10px] font-black tracking-[0.35em] uppercase text-gold/60 mb-2">Supplement</div>
+                    <h3 class="text-lg font-serif font-black text-white mb-3">${escapeHtml(rule.title)}</h3>
+                    <p class="text-sm text-gray-400 leading-loose">${textToHtml(rule.body)}</p>
+                </article>
+            `).join('')
+            : errorMarkup('補足ルールの記載はまだありません。');
+        const promotionHeading = page.promotion_heading || '昇格条件';
+        const relegationHeading = page.relegation_heading || '降格条件';
+
+        target.innerHTML = `
+            <section class="mb-12 md:mb-16">
+                <article class="relative overflow-hidden rounded-sm border border-gold/25 bg-black">
+                    <div class="absolute inset-0">
+                        ${imageTag(page.hero_image, page.title, 'w-full h-full object-cover opacity-30')}
+                        <div class="absolute inset-0 bg-gradient-to-r from-black via-black/90 to-black/55"></div>
+                        <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(212,175,55,0.18),transparent_42%)]"></div>
+                    </div>
+                    <div class="relative z-10 px-6 py-12 md:px-12 md:py-16">
+                        <div class="inline-flex flex-wrap gap-3 items-center mb-6">
+                            <span class="border border-gold/30 px-3 py-1 text-[10px] font-black tracking-[0.45em] uppercase text-gold">${escapeHtml(page.season_label)}</span>
+                            <span class="border border-white/10 px-3 py-1 text-[10px] font-black tracking-[0.35em] uppercase text-white/70">${escapeHtml(page.period_label)}</span>
+                        </div>
+                        <div class="max-w-3xl">
+                            <h1 class="text-3xl md:text-5xl font-serif font-black text-white tracking-widest leading-tight mb-6">${escapeHtml(page.title)}</h1>
+                            <p class="text-sm md:text-base text-gray-300 leading-loose mb-8">${escapeHtml(page.summary)}</p>
+                            <div class="flex flex-col sm:flex-row gap-4">
+                                <a href="season-rules.html" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                                    制度一覧へ戻る <i class="fas fa-layer-group"></i>
+                                </a>
+                                <a href="${escapeHtml(page.stats_link || 'season_stats.html')}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                                    ランキングを見る <i class="fas fa-chart-line"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="jp-card p-6 md:p-8 corner-deco">
+                    <div class="flex items-center gap-3 mb-6">
+                        <i class="fas fa-scroll text-gold text-lg"></i>
+                        <h2 class="text-lg md:text-xl font-serif font-bold text-white">制度概要</h2>
+                    </div>
+                    <div class="space-y-5 text-sm md:text-base text-gray-300 leading-loose">
+                        <p>${textToHtml(page.overview || page.summary)}</p>
+                        <p>${textToHtml(page.description)}</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-sitemap text-gold"></i>
+                    <h2 class="text-lg md:text-xl font-serif font-bold text-white">制度図解</h2>
+                </div>
+                <figure class="jp-card p-4 md:p-6 corner-deco">
+                    <div class="overflow-hidden rounded-sm border border-white/10 bg-black">
+                        ${imageTag(page.diagram_image, page.diagram_caption || page.title, 'w-full h-auto object-cover')}
+                    </div>
+                    ${page.diagram_caption ? `<figcaption class="text-xs text-gray-500 tracking-[0.2em] uppercase mt-4">${escapeHtml(page.diagram_caption)}</figcaption>` : ''}
+                </figure>
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-arrow-up text-gold"></i>
+                    <h2 class="text-2xl md:text-3xl font-serif font-bold text-white">${escapeHtml(promotionHeading)}</h2>
+                </div>
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                    ${promotionMarkup}
+                </div>
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-arrow-down text-gold"></i>
+                    <h2 class="text-2xl md:text-3xl font-serif font-bold text-white">${escapeHtml(relegationHeading)}</h2>
+                </div>
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                    ${relegationMarkup}
+                </div>
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-list text-gold"></i>
+                    <h2 class="text-lg md:text-xl font-serif font-bold text-white">補足ルール</h2>
+                </div>
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
+                    ${extraRuleMarkup}
+                </div>
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-calendar-days text-gold"></i>
+                    <h2 class="text-lg md:text-xl font-serif font-bold text-white">シーズンスケジュール</h2>
+                </div>
+                ${renderScheduleTable(page)}
+            </section>
+
+            <section>
+                <div class="jp-card p-6 md:p-8 corner-deco">
+                    <div class="flex items-center gap-3 mb-6">
+                        <i class="fas fa-link text-gold"></i>
+                        <h2 class="text-lg font-serif font-bold text-white">関連リンク</h2>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                        ${renderRelatedLinkCard({
+                            eyebrow: 'Prev',
+                            title: previousSeasonPage ? '前シーズンガイド' : '前シーズンなし',
+                            description: previousSeasonPage
+                                ? `${previousSeasonPage.season_label} の制度ガイドへ移動します。`
+                                : 'このページより前のシーズンガイドはありません。',
+                            href: previousSeasonPage ? detailUrl(previousSeasonPage.slug) : null,
+                            iconClass: 'fas fa-arrow-left',
+                            muted: !previousSeasonPage
+                        })}
+                        ${renderRelatedLinkCard({
+                            eyebrow: 'Next',
+                            title: nextSeasonPage ? '次シーズンガイド' : '次シーズンなし',
+                            description: nextSeasonPage
+                                ? `${nextSeasonPage.season_label} の制度ガイドへ移動します。`
+                                : 'このページより次のシーズンガイドはありません。',
+                            href: nextSeasonPage ? detailUrl(nextSeasonPage.slug) : null,
+                            iconClass: 'fas fa-arrow-right',
+                            muted: !nextSeasonPage
+                        })}
+                        ${renderRelatedLinkCard({
+                            eyebrow: 'Hub',
+                            title: '制度一覧ページ',
+                            description: '全シーズンの制度ページと現在シーズンの導線をまとめて確認できます。',
+                            href: 'season-rules.html',
+                            iconClass: 'fas fa-layer-group'
+                        })}
+                        ${renderRelatedLinkCard({
+                            eyebrow: 'Stats',
+                            title: 'シーズンランキング',
+                            description: '実際の順位とスタッツを見ながら制度条件を確認できます。',
+                            href: page.stats_link || 'season_stats.html',
+                            iconClass: 'fas fa-chart-line'
+                        })}
+                    </div>
+                </div>
+            </section>
+        `;
+    }
+
+    async function loadConfig() {
+        const response = await fetch(CONFIG_PATH);
+        if (!response.ok) {
+            throw new Error('season_rule_pages.json の読み込みに失敗しました。');
+        }
+        return response.json();
+    }
+
+    async function init() {
+        const mode = document.body.dataset.pageMode;
+        if (!mode) return;
+
+        const hubTarget = document.getElementById('season-rules-current');
+        const detailTarget = document.getElementById('season-rule-detail');
+
+        if (hubTarget) hubTarget.innerHTML = loadingMarkup();
+        if (detailTarget) detailTarget.innerHTML = loadingMarkup();
+
+        try {
+            const config = await loadConfig();
+
+            if (mode === 'season-rules-index') {
+                renderHub(config);
+                return;
+            }
+
+            if (mode === 'season-rules-detail') {
+                renderDetail(config, document.body.dataset.seasonRuleSlug);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : '制度ページの読み込みに失敗しました。';
+
+            if (hubTarget) hubTarget.innerHTML = errorMarkup(message);
+            if (detailTarget) detailTarget.innerHTML = errorMarkup(message);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/js/season-rules.js
+++ b/js/season-rules.js
@@ -112,6 +112,44 @@
         return `<a href="${escapeHtml(href)}" class="${baseClass}">${content}</a>`;
     }
 
+    function renderSeasonSwitchButton(options) {
+        const {
+            label,
+            title,
+            description,
+            href,
+            iconClass,
+            muted
+        } = options;
+
+        const content = `
+            <div class="flex items-center justify-between gap-4">
+                <div class="min-w-0">
+                    <div class="text-[10px] font-black tracking-[0.35em] uppercase text-gold/60 mb-2">${escapeHtml(label)}</div>
+                    <div class="text-xl md:text-2xl font-serif font-black text-white mb-2">${escapeHtml(title)}</div>
+                    <p class="text-sm text-gray-400 leading-loose">${escapeHtml(description)}</p>
+                </div>
+                <div class="w-12 h-12 md:w-14 md:h-14 shrink-0 rounded-full border border-white/10 bg-white/5 flex items-center justify-center text-gold">
+                    <i class="${escapeHtml(iconClass)}"></i>
+                </div>
+            </div>
+        `;
+
+        const baseClass = muted
+            ? 'block jp-card p-6 md:p-7 corner-deco opacity-55'
+            : 'group block jp-card p-6 md:p-7 corner-deco hover:border-gold/40 transition-all duration-300';
+
+        if (muted || !href) {
+            return `<div class="${baseClass}">${content}</div>`;
+        }
+
+        return `
+            <a href="${escapeHtml(href)}" class="${baseClass}">
+                ${content}
+            </a>
+        `;
+    }
+
     function renderScheduleTable(page) {
         const schedule = Array.isArray(page.schedule) ? page.schedule : [];
 
@@ -152,6 +190,42 @@
         `;
     }
 
+    function renderSponsorshipSection(page) {
+        const sponsorship = page.sponsorship;
+
+        if (!sponsorship || !sponsorship.image) {
+            return `
+                <div class="jp-card p-5 md:p-6 corner-deco">
+                    <p class="text-sm text-gray-400 leading-loose">本シーズンへの協賛はありません。</p>
+                </div>
+            `;
+        }
+
+        const imageMarkup = imageTag(
+            sponsorship.image,
+            sponsorship.alt || `${page.title} の協賛画像`,
+            'w-full h-auto object-contain transition duration-500 group-hover:scale-[1.01]'
+        );
+
+        if (!sponsorship.href) {
+            return `
+                <figure class="jp-card p-4 md:p-6 corner-deco">
+                    <div class="overflow-hidden rounded-sm border border-white/10 bg-black">
+                        ${imageMarkup}
+                    </div>
+                </figure>
+            `;
+        }
+
+        return `
+            <a href="${escapeHtml(sponsorship.href)}" class="group block jp-card p-4 md:p-6 corner-deco hover:border-gold/40 transition-all duration-300">
+                <div class="overflow-hidden rounded-sm border border-white/10 bg-black">
+                    ${imageMarkup}
+                </div>
+            </a>
+        `;
+    }
+
     function renderCurrentFeature(page, isCurrent) {
         return `
             <article class="relative overflow-hidden rounded-sm border border-gold/30 bg-black">
@@ -171,7 +245,7 @@
                         <p class="text-sm md:text-base text-gray-300 leading-loose mb-8">${escapeHtml(page.summary)}</p>
                         <div class="flex flex-col sm:flex-row gap-4">
                             <a href="${detailUrl(page.slug)}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.3em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
-                                制度詳細を見る <i class="fas fa-arrow-right"></i>
+                                シーズン条件を見る <i class="fas fa-arrow-right"></i>
                             </a>
                             <a href="${escapeHtml(page.stats_link || 'season_stats.html')}" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
                                 ランキングを見る <i class="fas fa-chart-line"></i>
@@ -223,7 +297,7 @@
                         </div>
                         <p class="text-xs text-gray-400 leading-relaxed">${escapeHtml(page.summary)}</p>
                         <div class="pt-1 flex items-center justify-between text-[11px] font-black tracking-[0.2em] uppercase text-gold">
-                            <span>詳細を見る</span>
+                            <span>条件を見る</span>
                             <i class="fas fa-arrow-right transition-transform duration-300 group-hover:translate-x-1"></i>
                         </div>
                     </div>
@@ -240,7 +314,7 @@
         const pageIndex = pages.findIndex((item) => item.slug === slug);
         const page = pageIndex >= 0 ? pages[pageIndex] : null;
         if (!page) {
-            target.innerHTML = errorMarkup('指定されたシーズン制度ページが見つかりませんでした。');
+            target.innerHTML = errorMarkup('指定されたシーズン条件ページが見つかりませんでした。');
             return;
         }
 
@@ -272,6 +346,9 @@
             : errorMarkup('補足ルールの記載はまだありません。');
         const promotionHeading = page.promotion_heading || '昇格条件';
         const relegationHeading = page.relegation_heading || '降格条件';
+        const descriptionMarkup = page.description
+            ? `<p>${textToHtml(page.description)}</p>`
+            : '';
 
         target.innerHTML = `
             <section class="mb-12 md:mb-16">
@@ -291,7 +368,7 @@
                             <p class="text-sm md:text-base text-gray-300 leading-loose mb-8">${escapeHtml(page.summary)}</p>
                             <div class="flex flex-col sm:flex-row gap-4">
                                 <a href="season-rules.html" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
-                                    制度一覧へ戻る <i class="fas fa-layer-group"></i>
+                                    シーズン条件一覧へ戻る <i class="fas fa-layer-group"></i>
                                 </a>
                                 <a href="${escapeHtml(page.stats_link || 'season_stats.html')}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                                     ランキングを見る <i class="fas fa-chart-line"></i>
@@ -310,7 +387,7 @@
                     </div>
                     <div class="space-y-5 text-sm md:text-base text-gray-300 leading-loose">
                         <p>${textToHtml(page.overview || page.summary)}</p>
-                        <p>${textToHtml(page.description)}</p>
+                        ${descriptionMarkup}
                     </div>
                 </div>
             </section>
@@ -366,37 +443,54 @@
                 ${renderScheduleTable(page)}
             </section>
 
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-handshake text-gold"></i>
+                    <h2 class="text-lg md:text-xl font-serif font-bold text-white">協賛内容</h2>
+                </div>
+                ${renderSponsorshipSection(page)}
+            </section>
+
+            <section class="mb-12 md:mb-16">
+                <div class="flex items-center gap-3 mb-6">
+                    <i class="fas fa-arrow-right-arrow-left text-gold"></i>
+                    <h2 class="text-lg md:text-xl font-serif font-bold text-white">season切り替え</h2>
+                </div>
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+                    ${renderSeasonSwitchButton({
+                        label: 'Prev Season',
+                        title: previousSeasonPage ? previousSeasonPage.season_label : '前シーズンなし',
+                        description: previousSeasonPage
+                            ? `${previousSeasonPage.season_label} のシーズン条件へ移動します。`
+                            : 'このページより前のシーズン条件ページはありません。',
+                        href: previousSeasonPage ? detailUrl(previousSeasonPage.slug) : null,
+                        iconClass: 'fas fa-arrow-left',
+                        muted: !previousSeasonPage
+                    })}
+                    ${renderSeasonSwitchButton({
+                        label: 'Next Season',
+                        title: nextSeasonPage ? nextSeasonPage.season_label : '次シーズンなし',
+                        description: nextSeasonPage
+                            ? `${nextSeasonPage.season_label} のシーズン条件へ移動します。`
+                            : 'このページより次のシーズン条件ページはありません。',
+                        href: nextSeasonPage ? detailUrl(nextSeasonPage.slug) : null,
+                        iconClass: 'fas fa-arrow-right',
+                        muted: !nextSeasonPage
+                    })}
+                </div>
+            </section>
+
             <section>
                 <div class="jp-card p-6 md:p-8 corner-deco">
                     <div class="flex items-center gap-3 mb-6">
                         <i class="fas fa-link text-gold"></i>
                         <h2 class="text-lg font-serif font-bold text-white">関連リンク</h2>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                        ${renderRelatedLinkCard({
-                            eyebrow: 'Prev',
-                            title: previousSeasonPage ? '前シーズンガイド' : '前シーズンなし',
-                            description: previousSeasonPage
-                                ? `${previousSeasonPage.season_label} の制度ガイドへ移動します。`
-                                : 'このページより前のシーズンガイドはありません。',
-                            href: previousSeasonPage ? detailUrl(previousSeasonPage.slug) : null,
-                            iconClass: 'fas fa-arrow-left',
-                            muted: !previousSeasonPage
-                        })}
-                        ${renderRelatedLinkCard({
-                            eyebrow: 'Next',
-                            title: nextSeasonPage ? '次シーズンガイド' : '次シーズンなし',
-                            description: nextSeasonPage
-                                ? `${nextSeasonPage.season_label} の制度ガイドへ移動します。`
-                                : 'このページより次のシーズンガイドはありません。',
-                            href: nextSeasonPage ? detailUrl(nextSeasonPage.slug) : null,
-                            iconClass: 'fas fa-arrow-right',
-                            muted: !nextSeasonPage
-                        })}
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                         ${renderRelatedLinkCard({
                             eyebrow: 'Hub',
-                            title: '制度一覧ページ',
-                            description: '全シーズンの制度ページと現在シーズンの導線をまとめて確認できます。',
+                            title: 'シーズン条件一覧',
+                            description: '全シーズンの条件ページと現在シーズンの導線をまとめて確認できます。',
                             href: 'season-rules.html',
                             iconClass: 'fas fa-layer-group'
                         })}

--- a/season-rules-s1.html
+++ b/season-rules-s1.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <link rel="icon" href="images/favicon.png" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>シーズン1制度ガイド | ポーカー鳳凰戦</title>
+    <title>シーズン1条件 | ポーカー鳳凰戦</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.seekerstart.com/houou/season-rules-s1.html">
-    <meta name="description" content="ポーカー鳳凰戦シーズン1の昇格・降格・認定条件をまとめた制度ガイドです。">
+    <meta name="description" content="ポーカー鳳凰戦シーズン1の昇格・降格・認定条件をまとめたページです。">
     <script>if(location.hostname==='seekerstart-hp.vercel.app')location.replace('https://www.seekerstart.com/houou/'+location.pathname.slice(1)+location.search+location.hash);</script>
 </head>
 <body class="antialiased" data-page-mode="season-rules-detail" data-season-rule-slug="s1">

--- a/season-rules-s1.html
+++ b/season-rules-s1.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ja" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="images/favicon.png" type="image/png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>シーズン1制度ガイド | ポーカー鳳凰戦</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="canonical" href="https://www.seekerstart.com/houou/season-rules-s1.html">
+    <meta name="description" content="ポーカー鳳凰戦シーズン1の昇格・降格・認定条件をまとめた制度ガイドです。">
+    <script>if(location.hostname==='seekerstart-hp.vercel.app')location.replace('https://www.seekerstart.com/houou/'+location.pathname.slice(1)+location.search+location.hash);</script>
+</head>
+<body class="antialiased" data-page-mode="season-rules-detail" data-season-rule-slug="s1">
+
+    <div id="site-header"></div>
+
+    <main class="pt-32 pb-24 min-h-screen">
+        <div class="container mx-auto px-6 max-w-6xl">
+            <div id="season-rule-detail"></div>
+        </div>
+    </main>
+
+    <footer class="bg-[#050505] py-12 border-t border-white/5">
+        <div class="container mx-auto px-6 text-center">
+            <div class="flex items-center justify-center gap-4 mb-6">
+                <img src="images/SeekerStart_logo.png" alt="Logo" class="h-6 w-auto" onerror="this.src='https://via.placeholder.com/80x30/111/d4af37?text=Logo'">
+                <span class="text-base font-serif font-black tracking-[0.2em] text-white">ポーカー鳳凰戦</span>
+            </div>
+            <p class="text-gray-600 text-[10px] mb-6">
+                Seeker Start 運営による公式シーズン制度ページ
+            </p>
+            <div class="text-[9px] text-gray-700 font-bold uppercase tracking-[0.4em]">
+                &copy; 2026 POKER HOUOU LEAGUE. ALL RIGHTS RESERVED.
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/header.js"></script>
+    <script src="js/season-rules.js"></script>
+</body>
+</html>

--- a/season-rules-s2.html
+++ b/season-rules-s2.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ja" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="images/favicon.png" type="image/png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>シーズン2制度ガイド | ポーカー鳳凰戦</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="canonical" href="https://www.seekerstart.com/houou/season-rules-s2.html">
+    <meta name="description" content="ポーカー鳳凰戦シーズン2の仮条件ページです。昇格・降格・認定条件の表示イメージを確認できます。">
+    <script>if(location.hostname==='seekerstart-hp.vercel.app')location.replace('https://www.seekerstart.com/houou/'+location.pathname.slice(1)+location.search+location.hash);</script>
+</head>
+<body class="antialiased" data-page-mode="season-rules-detail" data-season-rule-slug="s2">
+
+    <div id="site-header"></div>
+
+    <main class="pt-32 pb-24 min-h-screen">
+        <div class="container mx-auto px-6 max-w-6xl">
+            <div id="season-rule-detail"></div>
+        </div>
+    </main>
+
+    <footer class="bg-[#050505] py-12 border-t border-white/5">
+        <div class="container mx-auto px-6 text-center">
+            <div class="flex items-center justify-center gap-4 mb-6">
+                <img src="images/SeekerStart_logo.png" alt="Logo" class="h-6 w-auto" onerror="this.src='https://via.placeholder.com/80x30/111/d4af37?text=Logo'">
+                <span class="text-base font-serif font-black tracking-[0.2em] text-white">ポーカー鳳凰戦</span>
+            </div>
+            <p class="text-gray-600 text-[10px] mb-6">
+                Seeker Start 運営による公式シーズン制度ページ
+            </p>
+            <div class="text-[9px] text-gray-700 font-bold uppercase tracking-[0.4em]">
+                &copy; 2026 POKER HOUOU LEAGUE. ALL RIGHTS RESERVED.
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/header.js"></script>
+    <script src="js/season-rules.js"></script>
+</body>
+</html>

--- a/season-rules-s2.html
+++ b/season-rules-s2.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="images/favicon.png" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>シーズン2制度ガイド | ポーカー鳳凰戦</title>
+    <title>シーズン2条件 | ポーカー鳳凰戦</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">

--- a/season-rules.html
+++ b/season-rules.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="ja" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="images/favicon.png" type="image/png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>シーズン制度一覧 | ポーカー鳳凰戦</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="canonical" href="https://www.seekerstart.com/houou/season-rules.html">
+    <meta name="description" content="ポーカー鳳凰戦の各シーズン制度をまとめた一覧ページです。現在シーズンの昇格・降格条件と、制度アーカイブへアクセスできます。">
+    <script>if(location.hostname==='seekerstart-hp.vercel.app')location.replace('https://www.seekerstart.com/houou/'+location.pathname.slice(1)+location.search+location.hash);</script>
+</head>
+<body class="antialiased" data-page-mode="season-rules-index">
+
+    <div id="site-header"></div>
+
+    <main class="pt-32 pb-24 min-h-screen">
+        <div class="container mx-auto px-6 max-w-6xl">
+            <section class="text-center mb-14 md:mb-16">
+                <div class="inline-block px-4 py-1 border border-gold/30 mb-6">
+                    <span class="text-gold text-[9px] font-bold tracking-[0.5em] uppercase">Season Rules</span>
+                </div>
+                <h1 class="text-3xl md:text-5xl font-serif font-black text-white mb-6 tracking-widest">
+                    シーズン制度<span class="gold-gradient">一覧</span>
+                </h1>
+                <p class="text-sm text-gray-400 max-w-3xl mx-auto leading-loose">
+                    各シーズンの昇格・降格・認定条件をまとめた公式ガイドです。
+                    今シーズンの制度を最優先で確認でき、過去シーズンの制度ページもアーカイブとして積み上げていきます。
+                </p>
+            </section>
+
+            <section class="mb-16">
+                <div id="season-rules-current"></div>
+            </section>
+
+            <section class="mb-16">
+                <div class="jp-card p-6 md:p-8 corner-deco">
+                    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+                        <div>
+                            <div class="text-[10px] font-black tracking-[0.45em] uppercase text-gold/60 mb-3">Live Data</div>
+                            <h2 class="text-2xl font-serif font-black text-white mb-3">ランキングページとあわせて確認</h2>
+                            <p class="text-sm text-gray-400 leading-loose max-w-2xl">
+                                制度ページはルールの原本、ランキングページはシーズンの実績確認用です。
+                                昇格ラインや認定条件を把握したうえで、現在の順位やスタッツを確認できます。
+                            </p>
+                        </div>
+                        <a href="season_stats.html" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.3em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                            ランキングを見る <i class="fas fa-arrow-right"></i>
+                        </a>
+                    </div>
+                </div>
+            </section>
+
+            <section>
+                <div class="flex items-center justify-between gap-4 mb-6">
+                    <div>
+                        <div class="text-[10px] font-black tracking-[0.45em] uppercase text-white/35 mb-2">Archive</div>
+                        <h2 class="text-2xl md:text-3xl font-serif font-black text-white">制度アーカイブ</h2>
+                    </div>
+                    <div class="text-[10px] font-black tracking-[0.35em] uppercase text-gray-500">Season by Season</div>
+                </div>
+                <div id="season-rules-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-5"></div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="bg-[#050505] py-12 border-t border-white/5">
+        <div class="container mx-auto px-6 text-center">
+            <div class="flex items-center justify-center gap-4 mb-6">
+                <img src="images/SeekerStart_logo.png" alt="Logo" class="h-6 w-auto" onerror="this.src='https://via.placeholder.com/80x30/111/d4af37?text=Logo'">
+                <span class="text-base font-serif font-black tracking-[0.2em] text-white">ポーカー鳳凰戦</span>
+            </div>
+            <p class="text-gray-600 text-[10px] mb-6">
+                Seeker Start 運営による公式シーズン制度ページ
+            </p>
+            <div class="text-[9px] text-gray-700 font-bold uppercase tracking-[0.4em]">
+                &copy; 2026 POKER HOUOU LEAGUE. ALL RIGHTS RESERVED.
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/header.js"></script>
+    <script src="js/season-rules.js"></script>
+</body>
+</html>

--- a/season-rules.html
+++ b/season-rules.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <link rel="icon" href="images/favicon.png" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>シーズン制度一覧 | ポーカー鳳凰戦</title>
+    <title>シーズン条件一覧 | ポーカー鳳凰戦</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.seekerstart.com/houou/season-rules.html">
-    <meta name="description" content="ポーカー鳳凰戦の各シーズン制度をまとめた一覧ページです。現在シーズンの昇格・降格条件と、制度アーカイブへアクセスできます。">
+    <meta name="description" content="ポーカー鳳凰戦の各シーズン条件をまとめた一覧ページです。現在シーズンの条件と、条件アーカイブへアクセスできます。">
     <script>if(location.hostname==='seekerstart-hp.vercel.app')location.replace('https://www.seekerstart.com/houou/'+location.pathname.slice(1)+location.search+location.hash);</script>
 </head>
 <body class="antialiased" data-page-mode="season-rules-index">
@@ -23,11 +23,11 @@
                     <span class="text-gold text-[9px] font-bold tracking-[0.5em] uppercase">Season Rules</span>
                 </div>
                 <h1 class="text-3xl md:text-5xl font-serif font-black text-white mb-6 tracking-widest">
-                    シーズン制度<span class="gold-gradient">一覧</span>
+                    シーズン条件<span class="gold-gradient">一覧</span>
                 </h1>
                 <p class="text-sm text-gray-400 max-w-3xl mx-auto leading-loose">
-                    各シーズンの昇格・降格・認定条件をまとめた公式ガイドです。
-                    今シーズンの制度を最優先で確認でき、過去シーズンの制度ページもアーカイブとして積み上げていきます。
+                    各シーズンの昇格・降格・認定条件をまとめた一覧ページです。
+                    今シーズンの条件を最優先で確認でき、過去シーズンの条件ページもアーカイブとして確認できます。
                 </p>
             </section>
 
@@ -57,7 +57,7 @@
                 <div class="flex items-center justify-between gap-4 mb-6">
                     <div>
                         <div class="text-[10px] font-black tracking-[0.45em] uppercase text-white/35 mb-2">Archive</div>
-                        <h2 class="text-2xl md:text-3xl font-serif font-black text-white">制度アーカイブ</h2>
+                        <h2 class="text-2xl md:text-3xl font-serif font-black text-white">シーズン条件アーカイブ</h2>
                     </div>
                     <div class="text-[10px] font-black tracking-[0.35em] uppercase text-gray-500">Season by Season</div>
                 </div>


### PR DESCRIPTION
## Summary
- add season rules hub and season detail pages
- add shared season rules config and renderer
- update navigation and top page links to point to the new season rules pages

## Notes
- includes provisional Season 2 guide content and schedule table support
- keeps local .codex helper files out of the commit