### PR TITLE
Fix missing /houou/ in internal links

### DIFF
--- a/config/season_rule_pages.json
+++ b/config/season_rule_pages.json
@@ -47,7 +47,7 @@
       ],
       "diagram_image": "images/season2-guide.png",
       "diagram_caption": "",
-      "stats_link": "season_stats.html"
+      "stats_link": "/houou/season_stats.html"
     },
     {
       "slug": "s1",
@@ -93,9 +93,9 @@
       "sponsorship": {
         "image": "images/jopt_season1.jpg",
         "alt": "JOPT協賛決定 鳳凰戦 Season 1 Cリーグ賞品",
-        "href": "sponsor.html"
+        "href": "/houou/sponsor.html"
       },
-      "stats_link": "season_stats.html"
+      "stats_link": "/houou/season_stats.html"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -123,10 +123,10 @@
                         最新制度と過去シーズンの条件差分は、専用の制度ページで確認できます。
                     </p>
                     <div class="flex flex-col sm:flex-row gap-3">
-                        <a href="season-rules-s1.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                        <a href="/houou/season-rules-s1.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                             今季の制度を見る <i class="fas fa-arrow-right"></i>
                         </a>
-                        <a href="season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                        <a href="/houou/season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
                             シーズン条件一覧へ
                         </a>
                     </div>
@@ -420,10 +420,10 @@
                         </p>
                     </div>
                     <div class="flex flex-col sm:flex-row justify-center gap-3 pt-2">
-                        <a href="season-rules-s1.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                        <a href="/houou/season-rules-s1.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                             今季の制度ページ <i class="fas fa-arrow-right"></i>
                         </a>
-                        <a href="season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                        <a href="/houou/season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
                             シーズン条件一覧を見る
                         </a>
                     </div>
@@ -440,7 +440,7 @@
             </div>
 
             <div class="reveal delay-100">
-                <a href="season_stats.html" class="group block jp-card p-8 md:p-12 corner-deco text-center hover:border-gold transition-all duration-500">
+                <a href="/houou/season_stats.html" class="group block jp-card p-8 md:p-12 corner-deco text-center hover:border-gold transition-all duration-500">
                     <div class="flex flex-col md:flex-row items-center justify-center gap-6 md:gap-10">
                         <div class="w-20 h-20 rounded-full border border-gold/40 flex items-center justify-center bg-black/50 group-hover:border-gold group-hover:shadow-[0_0_30px_rgba(212,175,55,0.2)] transition-all duration-500">
                             <i class="fas fa-chart-bar text-3xl text-gold"></i>

--- a/js/header.js
+++ b/js/header.js
@@ -1,11 +1,14 @@
-// Shared Header — single source of truth for all pages
+// Shared Header - single source of truth for all pages
 (function () {
+    const INTERNAL_BASE_PATH = '/houou/';
+    const pageHref = (path) => `${INTERNAL_BASE_PATH}${String(path).replace(/^\/+/, '')}`;
+
     const NAV_ITEMS = [
-        { label: 'トップ', href: 'index.html' },
-        { label: 'ランキング', href: 'season_stats.html' },
-        { label: 'シーズン制度', href: 'season-rules.html' },
-        { label: '注目選手', href: 'pickup.html' },
-        { label: '協賛一覧', href: 'sponsor.html' },
+        { label: 'トップ', href: pageHref('index.html') },
+        { label: 'ランキング', href: pageHref('season_stats.html') },
+        { label: 'シーズン制度', href: pageHref('season-rules.html') },
+        { label: '注目選手', href: pageHref('pickup.html') },
+        { label: '協賛一覧', href: pageHref('sponsor.html') },
     ];
 
     const CTA = { label: '参戦申込', href: 'https://x.com/seekerstart' };
@@ -30,7 +33,7 @@
         <header id="nav" class="fixed w-full z-[100] bg-black/90 backdrop-blur-md border-b border-white/5 transition-all duration-500">
             <div class="container mx-auto px-4 sm:px-6 lg:px-10 py-4 flex justify-between items-center">
                 <!-- Logo -->
-                <a href="index.html" class="flex items-center gap-3 sm:gap-4 md:gap-5">
+                <a href="${pageHref('index.html')}" class="flex items-center gap-3 sm:gap-4 md:gap-5">
                     <div class="bg-white/10 p-1 rounded shrink-0">
                         <img src="images/SeekerStart_logo.png" alt="Logo" class="h-7 sm:h-8 md:h-9 w-auto" onerror="this.src='https://via.placeholder.com/100x40/111/d4af37?text=SS'">
                     </div>

--- a/js/pickup.js
+++ b/js/pickup.js
@@ -24,6 +24,16 @@ const CSS_CLASSES = {
 let seasonTabs = null;
 let featuredList = null;
 
+function normalizeSocialUrl(url) {
+    if (!url) return url;
+
+    if (url === 'https://seekerstart-hp.vercel.app/index.html' || url === 'https://seekerstart-hp.vercel.app/') {
+        return 'https://www.seekerstart.com/houou/';
+    }
+
+    return url;
+}
+
 /**
  * リンクが有効かどうかを判定
  */
@@ -37,12 +47,12 @@ function isEnabledLink(url) {
 function buildSocialIcons(player) {
     const social = player.social || {};
     const items = [
-        { label: 'X', icon: 'fa-brands fa-twitter', url: social.x, color: '#38bdf8' },
-        { label: 'YouTube', icon: 'fa-brands fa-youtube', url: social.youtube, color: '#ff0000' },
-        { label: 'Instagram', icon: 'fa-brands fa-instagram', url: social.instagram, color: '#e1306c', gradient: ['#f58529', '#feda77', '#dd2a7b', '#8134af', '#515bd4'] },
-        { label: 'TikTok', icon: 'fa-brands fa-tiktok', url: social.tiktok, color: '#25F4EE', gradient: ['#25F4EE', '#FE2C55'] },
-        { label: 'note', icon: 'fa-solid fa-note-sticky', url: social.note, color: '#00c300' },
-        { label: 'Website', icon: 'fa-solid fa-globe', url: social.website, color: '#d4af37' }
+        { label: 'X', icon: 'fa-brands fa-twitter', url: normalizeSocialUrl(social.x), color: '#38bdf8' },
+        { label: 'YouTube', icon: 'fa-brands fa-youtube', url: normalizeSocialUrl(social.youtube), color: '#ff0000' },
+        { label: 'Instagram', icon: 'fa-brands fa-instagram', url: normalizeSocialUrl(social.instagram), color: '#e1306c', gradient: ['#f58529', '#feda77', '#dd2a7b', '#8134af', '#515bd4'] },
+        { label: 'TikTok', icon: 'fa-brands fa-tiktok', url: normalizeSocialUrl(social.tiktok), color: '#25F4EE', gradient: ['#25F4EE', '#FE2C55'] },
+        { label: 'note', icon: 'fa-solid fa-note-sticky', url: normalizeSocialUrl(social.note), color: '#00c300' },
+        { label: 'Website', icon: 'fa-solid fa-globe', url: normalizeSocialUrl(social.website), color: '#d4af37' }
     ];
 
     return items.map((item) => {

--- a/js/season-rules.js
+++ b/js/season-rules.js
@@ -1,5 +1,7 @@
 (function () {
+    const INTERNAL_BASE_PATH = '/houou/';
     const CONFIG_PATH = 'config/season_rule_pages.json';
+    const pageHref = (path) => `${INTERNAL_BASE_PATH}${String(path).replace(/^\/+/, '')}`;
 
     function escapeHtml(value) {
         return String(value ?? '')
@@ -15,7 +17,7 @@
     }
 
     function detailUrl(slug) {
-        return `season-rules-${slug}.html`;
+        return pageHref(`season-rules-${slug}.html`);
     }
 
     function imageTag(src, alt, className) {
@@ -247,7 +249,7 @@
                             <a href="${detailUrl(page.slug)}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.3em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                                 シーズン条件を見る <i class="fas fa-arrow-right"></i>
                             </a>
-                            <a href="${escapeHtml(page.stats_link || 'season_stats.html')}" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                            <a href="${escapeHtml(page.stats_link || pageHref('season_stats.html'))}" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
                                 ランキングを見る <i class="fas fa-chart-line"></i>
                             </a>
                         </div>
@@ -367,10 +369,10 @@
                             <h1 class="text-3xl md:text-5xl font-serif font-black text-white tracking-widest leading-tight mb-6">${escapeHtml(page.title)}</h1>
                             <p class="text-sm md:text-base text-gray-300 leading-loose mb-8">${escapeHtml(page.summary)}</p>
                             <div class="flex flex-col sm:flex-row gap-4">
-                                <a href="season-rules.html" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
+                                <a href="${pageHref('season-rules.html')}" class="inline-flex items-center justify-center gap-3 border border-white/10 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
                                     シーズン条件一覧へ戻る <i class="fas fa-layer-group"></i>
                                 </a>
-                                <a href="${escapeHtml(page.stats_link || 'season_stats.html')}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                                <a href="${escapeHtml(page.stats_link || pageHref('season_stats.html'))}" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.25em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                                     ランキングを見る <i class="fas fa-chart-line"></i>
                                 </a>
                             </div>
@@ -491,14 +493,14 @@
                             eyebrow: 'Hub',
                             title: 'シーズン条件一覧',
                             description: '全シーズンの条件ページと現在シーズンの導線をまとめて確認できます。',
-                            href: 'season-rules.html',
+                            href: pageHref('season-rules.html'),
                             iconClass: 'fas fa-layer-group'
                         })}
                         ${renderRelatedLinkCard({
                             eyebrow: 'Stats',
                             title: 'シーズンランキング',
                             description: '実際の順位とスタッツを見ながら制度条件を確認できます。',
-                            href: page.stats_link || 'season_stats.html',
+                            href: page.stats_link || pageHref('season_stats.html'),
                             iconClass: 'fas fa-chart-line'
                         })}
                     </div>

--- a/js/stats-loader.js
+++ b/js/stats-loader.js
@@ -4,6 +4,7 @@
  */
 
 const StatsLoader = {
+    internalBasePath: '/houou/',
     // CSVパス設定
     allStatsPath: 'data/all_stats.csv',
     seasonStatsPathTemplate: 'data/season_{id}_stats.csv',
@@ -19,6 +20,10 @@ const StatsLoader = {
     // ソート設定
     currentSortColumn: '収支',  // デフォルトは収支でソート
     currentSortOrder: 'desc',  // desc: 降順, asc: 昇順
+
+    pageHref(path) {
+        return `${this.internalBasePath}${String(path).replace(/^\/+/, '')}`;
+    },
 
     /**
      * 初期化
@@ -389,7 +394,7 @@ const StatsLoader = {
 
             row.innerHTML = `
                 <td class="py-4 px-3 text-center text-gold font-bold text-sm">${rank}</td>
-                <td class="py-4 px-3 text-white font-bold text-sm whitespace-nowrap"><a href="user.html?id=${encodeURIComponent(player['player_id'])}" class="player-name-link">${this.escapeHtml(player['プレイヤー'])}</a></td>
+                <td class="py-4 px-3 text-white font-bold text-sm whitespace-nowrap"><a href="${this.pageHref('user.html')}?id=${encodeURIComponent(player['player_id'])}" class="player-name-link">${this.escapeHtml(player['プレイヤー'])}</a></td>
                 <td class="py-4 px-3 text-center">${leagueBadge}</td>
                 <td class="py-4 px-3 text-right text-sm font-mono ${profitClass}">${this.escapeHtml(profitBBStr)}</td>
                 <td class="py-4 px-3 text-right text-gray-300 text-sm font-mono">${this.escapeHtml(player['ハンド数'])}</td>

--- a/js/user-loader.js
+++ b/js/user-loader.js
@@ -4,6 +4,7 @@
  */
 
 const UserLoader = {
+    internalBasePath: '/houou/',
     // パス設定
     seasonsConfigPath: 'config/seasons.json',
     sessionStatsPath: 'data/session_stats.csv',
@@ -20,6 +21,10 @@ const UserLoader = {
     playerId: null,
     currentSeasonId: null,
     chartInstance: null,
+
+    pageHref(path) {
+        return `${this.internalBasePath}${String(path).replace(/^\/+/, '')}`;
+    },
 
     /**
      * 初期化
@@ -802,7 +807,7 @@ const UserLoader = {
             <div class="py-12 text-center">
                 <i class="fas fa-exclamation-triangle text-2xl mb-4 block text-red-400/50"></i>
                 <p class="text-gray-500">${this.escapeHtml(message)}</p>
-                <a href="season_stats.html" class="inline-block mt-4 text-gold text-sm hover:underline">
+                <a href="${this.pageHref('season_stats.html')}" class="inline-block mt-4 text-gold text-sm hover:underline">
                     ランキングページに戻る
                 </a>
             </div>

--- a/scripts/local-static-server.js
+++ b/scripts/local-static-server.js
@@ -5,6 +5,7 @@ const path = require('path');
 const root = process.cwd();
 const port = Number(process.env.PORT || 8000);
 const host = process.env.HOST || '0.0.0.0';
+const basePath = '/houou';
 
 const mimeTypes = {
   '.html': 'text/html; charset=utf-8',
@@ -23,7 +24,16 @@ const mimeTypes = {
 http
   .createServer((req, res) => {
     const requestPath = decodeURIComponent((req.url || '/').split('?')[0]);
-    const relativePath = requestPath === '/' ? '/index.html' : requestPath;
+    let relativePath = requestPath;
+
+    if (requestPath === basePath || requestPath === `${basePath}/`) {
+      relativePath = '/index.html';
+    } else if (requestPath.startsWith(`${basePath}/`)) {
+      relativePath = requestPath.slice(basePath.length);
+    } else if (requestPath === '/') {
+      relativePath = '/index.html';
+    }
+
     const filePath = path.normalize(path.join(root, relativePath));
 
     if (!filePath.startsWith(root)) {

--- a/scripts/local-static-server.js
+++ b/scripts/local-static-server.js
@@ -1,0 +1,52 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+const port = Number(process.env.PORT || 8000);
+const host = process.env.HOST || '0.0.0.0';
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+};
+
+http
+  .createServer((req, res) => {
+    const requestPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    const relativePath = requestPath === '/' ? '/index.html' : requestPath;
+    const filePath = path.normalize(path.join(root, relativePath));
+
+    if (!filePath.startsWith(root)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+
+    fs.stat(filePath, (error, stats) => {
+      if (error || !stats.isFile()) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      res.writeHead(200, {
+        'Content-Type':
+          mimeTypes[path.extname(filePath).toLowerCase()] || 'application/octet-stream',
+      });
+
+      fs.createReadStream(filePath).pipe(res);
+    });
+  })
+  .listen(port, host, () => {
+    console.log(`Static server listening on http://${host}:${port}`);
+  });

--- a/season-rules.html
+++ b/season-rules.html
@@ -46,7 +46,7 @@
                                 昇格ラインや認定条件を把握したうえで、現在の順位やスタッツを確認できます。
                             </p>
                         </div>
-                        <a href="season_stats.html" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.3em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                        <a href="/houou/season_stats.html" class="inline-flex items-center justify-center gap-3 border border-gold/40 px-6 py-3 text-xs font-black tracking-[0.3em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                             ランキングを見る <i class="fas fa-arrow-right"></i>
                         </a>
                     </div>

--- a/season_stats.html
+++ b/season_stats.html
@@ -34,7 +34,7 @@
 
             <!-- All Stats Link Box -->
             <div class="mb-12">
-                <a href="all_stats.html" class="group block bg-gradient-to-r from-gold/10 to-transparent border border-gold/30 p-6 rounded hover:border-gold/60 transition-all duration-300">
+                <a href="/houou/all_stats.html" class="group block bg-gradient-to-r from-gold/10 to-transparent border border-gold/30 p-6 rounded hover:border-gold/60 transition-all duration-300">
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-4">
                             <div class="w-12 h-12 rounded-full border border-gold/40 flex items-center justify-center bg-black/50 group-hover:border-gold transition-all duration-300">


### PR DESCRIPTION
## Summary
- fix internal page links so they consistently resolve under /houou/
- update dynamic link generation for header, stats, user, and season rules pages
- support /houou/ routes in the local static server for local verification

## Verification
- node --check js/header.js
- node --check js/season-rules.js
- node --check js/stats-loader.js
- node --check js/user-loader.js
- node --check js/pickup.js
- node --check scripts/local-static-server.js
- verified local responses for /houou/ and /houou/season_stats.html