### PR TITLE
トップページを Season 3 開幕情報に更新

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,6 +7,8 @@
     --silver-light: #e8e8e8;
     --bronze: #cd7f32;
     --bronze-light: #f4c49c;
+    --iron: #708090;
+    --iron-light: #b0b8c0;
     --red-vermilion: #b91c1c;
     --bg-deep: #050505;
     --bg-paper: #0a0a0a;
@@ -47,6 +49,12 @@ h1, h2, h3, .font-serif {
 
 .bronze-gradient {
     background: linear-gradient(to bottom, var(--bronze-light), var(--bronze), #8b4513);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.iron-gradient {
+    background: linear-gradient(to bottom, var(--iron-light), var(--iron), #2f3a48);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
@@ -123,6 +131,71 @@ h1, h2, h3, .font-serif {
 }
 .corner-deco::before { top: -2px; left: -2px; border-right: 0; border-bottom: 0; }
 .corner-deco::after { bottom: -2px; right: -2px; border-left: 0; border-top: 0; }
+
+/* ============================================
+   Hero Primary CTA (Season Entry)
+   ============================================ */
+.hero-cta {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.85rem;
+    padding: 1.1rem 3.2rem;
+    background: linear-gradient(135deg, var(--gold-light) 0%, var(--gold) 48%, #9c6b1a 100%);
+    color: #0a0a0a;
+    font-family: 'Noto Serif JP', serif;
+    font-weight: 900;
+    letter-spacing: 0.32em;
+    border: 1px solid rgba(247, 239, 138, 0.55);
+    box-shadow: 0 0 24px rgba(212, 175, 55, 0.3),
+                inset 0 1px 0 rgba(255, 255, 255, 0.45),
+                inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+    isolation: isolate;
+    white-space: nowrap;
+    transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.45s ease;
+}
+@media (max-width: 640px) {
+    .hero-cta {
+        padding: 1rem 1.9rem;
+        letter-spacing: 0.22em;
+        gap: 0.6rem;
+    }
+}
+.hero-cta:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 44px rgba(212, 175, 55, 0.55),
+                inset 0 1px 0 rgba(255, 255, 255, 0.55),
+                inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+.hero-cta::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -130%;
+    width: 55%;
+    height: 100%;
+    background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.65), transparent);
+    transform: skewX(-22deg);
+    z-index: -1;
+    animation: cta-shine 5.5s ease-in-out infinite;
+}
+.hero-cta .hero-cta-icon {
+    color: #2a1e05;
+    font-size: 0.85em;
+    filter: drop-shadow(0 1px 1px rgba(255, 255, 255, 0.35));
+}
+
+@keyframes cta-shine {
+    0% { left: -130%; }
+    22% { left: 150%; }
+    100% { left: 150%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hero-cta::before { animation: none; }
+}
 
 .player-thumb {
     width: 48px;
@@ -223,6 +296,12 @@ h1, h2, h3, .font-serif {
 .border-bronze { border-color: var(--bronze); }
 .border-bronze-30 { border-color: rgba(205, 127, 50, 0.3); }
 .divider-bronze { background: linear-gradient(to right, rgba(205, 127, 50, 0.5), transparent); }
+
+/* League Colors - Iron (D League) */
+.text-iron { color: var(--iron); }
+.border-iron { border-color: var(--iron); }
+.border-iron-30 { border-color: rgba(112, 128, 144, 0.3); }
+.divider-iron { background: linear-gradient(to right, rgba(112, 128, 144, 0.5), transparent); }
 
 /* Player Thumbnail Variants */
 .player-thumb-silver {

--- a/index.html
+++ b/index.html
@@ -47,20 +47,15 @@
 
             <!-- Balanced Hero Buttons -->
             <div class="reveal delay-200">
-                <p class="text-gray-400 text-xs sm:text-base font-light tracking-[0.1em] mb-12 max-w-xl mx-auto leading-loose">
+                <p class="text-gray-400 text-xs sm:text-base font-light tracking-[0.1em] mb-10 max-w-xl mx-auto leading-loose">
                     運に左右される一戦を超え、<br>
                     永続的な技量と精神力を評価する。
                 </p>
-                <div class="flex flex-col sm:flex-row gap-6 justify-center items-center">
-                    <!-- Button 1: 最新シーズン -->
-                    <a href="#season" class="group relative px-2 py-4 overflow-hidden w-60 text-center">
-                        <div class="absolute inset-0 border border-gold/50 group-hover:scale-105 transition duration-500"></div>
-                        <span class="relative z-10 text-gold text-xs font-black tracking-[0.4em] uppercase">最新シーズン</span>
-                    </a>
-                    <!-- Button 2: ランクシステム -->
-                    <a href="#league" class="group relative px-2 py-4 overflow-hidden w-60 text-center">
-                        <div class="absolute inset-0 border border-gold/50 group-hover:scale-105 transition duration-500"></div>
-                        <span class="relative z-10 text-gold text-xs font-black tracking-[0.4em] uppercase">ランクシステム</span>
+                <!-- Primary CTA: SEASON 3 参戦 -->
+                <div class="flex justify-center">
+                    <a href="https://fast-table-production.up.railway.app/" target="_blank" rel="noopener" class="hero-cta text-sm sm:text-base">
+                        <i class="fas fa-feather hero-cta-icon"></i>
+                        <span>Season 3 に参戦する</span>
                     </a>
                 </div>
             </div>
@@ -77,16 +72,17 @@
             <!-- 概要ヘッダー -->
             <div class="text-center mb-16 reveal">
                 <div class="inline-block px-4 py-1 border border-gold/30 mb-6">
-                    <span class="text-gold text-[9px] font-bold tracking-[0.5em] uppercase">Season 02</span>
+                    <span class="text-gold text-[9px] font-bold tracking-[0.5em] uppercase">Season 03</span>
                 </div>
                 <h2 class="text-3xl md:text-5xl font-serif font-black text-white mb-6 tracking-widest leading-tight">
-                    シーズン 2 <span class="gold-gradient italic">鳳凰戦開幕</span>
+                    シーズン 3 <span class="gold-gradient italic">鳳凰戦開幕</span>
                 </h2>
                 <div class="flex justify-center items-center gap-4 mb-10">
                     <div class="h-[1px] w-12 bg-white/10"></div>
-                    <span class="text-white font-serif font-black text-xl md:text-2xl tracking-widest italic">4/14 — 6/1</span>
+                    <span class="text-white font-serif font-black text-xl md:text-2xl tracking-widest italic">6/8 — 7/27</span>
                     <div class="h-[1px] w-12 bg-white/10"></div>
                 </div>
+                <p class="text-[10px] sm:text-xs text-gray-500 tracking-[0.3em] uppercase">全 8 節 / 毎週月曜開催</p>
             </div>
 
             <!-- 横長バナーエリア -->
@@ -94,11 +90,50 @@
                 <div class="relative group">
                     <div class="absolute -inset-1 bg-gradient-to-b from-gold/30 to-transparent blur-md opacity-20 group-hover:opacity-40 transition duration-1000"></div>
                     <div class="relative bg-black border border-white/10 rounded-sm overflow-hidden shadow-2xl">
-                        <img src="images/season2-guide.png" alt="Season 2 Banner" class="w-full h-auto object-cover" onerror="this.src='https://images.unsplash.com/photo-1518893063132-36e46dbe2428?auto=format&fit=crop&q=80&w=1200'">
+                        <img src="images/season3-guide.png" alt="Season 3 Banner" class="w-full h-auto object-cover" onerror="this.onerror=null;this.src='images/season2-guide.png'">
                         <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-60"></div>
                         <div class="absolute bottom-4 left-6">
-                            <span class="text-white/50 text-[10px] font-bold tracking-[0.5em] uppercase italic">Season 02 League Guide</span>
+                            <span class="text-white/50 text-[10px] font-bold tracking-[0.5em] uppercase italic">Season 03 League Guide</span>
                         </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 全8節 開催スケジュール -->
+            <div class="reveal mb-12 delay-150">
+                <h4 class="text-gold font-serif font-bold text-sm mb-5 tracking-widest text-center uppercase">開催スケジュール</h4>
+                <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2">
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 1 節</span>
+                        <span class="text-white text-xs font-serif font-bold">6/8</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 2 節</span>
+                        <span class="text-white text-xs font-serif font-bold">6/15</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 3 節</span>
+                        <span class="text-white text-xs font-serif font-bold">6/22</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 4 節</span>
+                        <span class="text-white text-xs font-serif font-bold">6/29</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 5 節</span>
+                        <span class="text-white text-xs font-serif font-bold">7/6</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 6 節</span>
+                        <span class="text-white text-xs font-serif font-bold">7/13</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 7 節</span>
+                        <span class="text-white text-xs font-serif font-bold">7/20</span>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 px-3 py-3 text-center">
+                        <span class="block text-[9px] text-gold tracking-widest mb-1">第 8 節</span>
+                        <span class="text-white text-xs font-serif font-bold">7/27</span>
                     </div>
                 </div>
             </div>
@@ -107,13 +142,13 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8 reveal delay-200">
                 <div class="bg-white/5 p-6 border-l-4 border-gold rounded-r-sm flex flex-col justify-center">
                     <h4 class="text-white font-serif font-black text-lg mb-3 flex items-center gap-3">
-                        <i class="fas fa-chess-knight text-gold text-sm"></i> Season 1 の結果を反映してリーグ分岐
+                        <i class="fas fa-chess-knight text-gold text-sm"></i> A / B / C / D の 4 リーグ制でスタート
                     </h4>
                     <p class="text-sm text-gray-400 leading-loose">
-                        シーズン2は、シーズン1の公式結果をもとに<span class="text-white font-bold">Bリーグ / Cリーグ</span>へ所属を振り分けて開幕します。新たな立ち位置から、昇格と残留を懸けた本格リーグ戦が始まります。
+                        シーズン3 では、最高位 <span class="text-white font-bold">A リーグ</span> の本格運用を開始し、新たに <span class="text-white font-bold">D リーグ</span> を新設。各リーグは「評価区分」として位置付けられ、全プレイヤーが同卓で混在して戦います。
                     </p>
                 </div>
-                
+
                 <div class="bg-white/5 p-6 border-l-4 border-white/20 rounded-r-sm flex flex-col justify-center">
                     <h4 class="text-white font-serif font-black text-lg mb-3 flex items-center gap-3">
                         <i class="fas fa-book-open text-gold text-sm"></i> シーズン制度ページ
@@ -131,12 +166,6 @@
                         </a>
                     </div>
                 </div>
-            </div>
-
-            <div class="mt-12 text-center reveal delay-300">
-                <p class="text-[10px] text-gray-600 italic">
-                    ※最高位「Aリーグ」は、今後のリーグ展開に合わせて段階的に形成・開放されます。
-                </p>
             </div>
         </div>
     </section>
@@ -197,7 +226,7 @@
                         <div class="flex-1 text-center md:text-left">
                             <h3 class="text-2xl md:text-3xl font-serif font-black text-gold mb-6 tracking-tighter">最高位「鳳凰位」</h3>
                             <p class="text-sm text-gray-400 leading-loose mb-8">
-                                Aリーグに<span class="text-white font-bold underline underline-offset-4 decoration-gold">三期連続</span>で所属。<br class="hidden sm:block">
+                                <span class="text-white font-bold underline underline-offset-4 decoration-gold">3 Season 連続</span>で A リーグに所属。<br class="hidden sm:block">
                                 実力の極致に達した者のみが冠する称号。鳳凰位は本リーグの象徴として、特別招待や広告起用など、様々な特待権利を有します。
                             </p>
                             <div class="flex flex-wrap justify-center md:justify-start gap-3">
@@ -215,41 +244,57 @@
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-0 items-stretch">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-0 items-stretch">
                 <!-- A League -->
-                <div class="jp-card p-10 bg-black reveal flex flex-col gap-8 delay-100 border-gold">
+                <div class="jp-card p-8 lg:p-6 bg-black reveal flex flex-col gap-6 delay-100 border-gold">
                     <div>
-                        <div class="flex justify-between items-start mb-8">
+                        <div class="flex justify-between items-start mb-6">
                             <span class="text-gold font-black text-[10px] tracking-widest uppercase">First Tier</span>
                             <span class="text-[9px] text-gold">神域</span>
                         </div>
                         <h3 class="text-2xl font-serif font-bold gold-gradient mb-4 italic">Aリーグ</h3>
-                        <p class="text-xs text-gray-400 leading-relaxed mb-10">選ばれし上位者のみが到達する最高峰。シーズン2時点では未開放で、次期以降の昇格先として位置付けられています。</p>
-                        <div class="h-[1px] w-full divider-gold mb-8"></div>
+                        <p class="text-xs text-gray-400 leading-relaxed mb-6">選ばれし上位者のみが到達する最高峰。Season 3 から本格運用が開始され、A リーグ残留と鳳凰位への到達を懸けた最高峰の戦いが始まる。</p>
+                        <div class="h-[1px] w-full divider-gold mb-6"></div>
+                    </div>
+                    <div class="mb-2">
+                        <h4 class="text-[9px] text-gold font-bold tracking-[0.2em] mb-3 border-b border-gold-10 pb-2">昇降格ルール</h4>
+                        <div class="rounded-sm border border-gold/15 bg-gold/5 px-4 py-4">
+                            <p class="text-[11px] text-gray-300 leading-loose">
+                                <span class="text-white font-bold">上位 3 名</span> 残留<br>
+                                <span class="text-white font-bold">下位 1 名</span> B リーグへ降格
+                            </p>
+                        </div>
                     </div>
                     <div>
-                        <h4 class="text-[9px] text-gold font-bold tracking-[0.2em] mb-5 border-b border-gold-10 pb-2">昇格先</h4>
-                        <div class="rounded-sm border border-gold/15 bg-gold/5 px-4 py-5">
-                            <p class="text-xs text-gray-300 leading-loose">
-                                Bリーグ上位帯の成績上位者が、次シーズン以降この舞台へ挑みます。
-                            </p>
+                        <h4 class="text-[9px] text-gold font-bold tracking-[0.2em] mb-3 border-b border-gold-10 pb-2">所属選手</h4>
+                        <div class="grid grid-cols-2 gap-2 text-[11px]">
+                            <!-- 運営追加予定 -->
                         </div>
                     </div>
                 </div>
 
                 <!-- B League (Silver) -->
-                <div class="jp-card p-10 bg-black lg:scale-105 z-10 shadow-2xl reveal flex flex-col gap-8 delay-100 border-silver">
+                <div class="jp-card p-8 lg:p-6 bg-black lg:scale-105 z-10 shadow-2xl reveal flex flex-col gap-6 delay-100 border-silver">
                     <div>
-                        <div class="flex justify-between items-start mb-8">
+                        <div class="flex justify-between items-start mb-6">
                             <span class="font-black text-[10px] tracking-widest uppercase text-silver">Second Tier</span>
                             <span class="text-[9px] text-silver">激戦</span>
                         </div>
                         <h3 class="text-2xl font-serif font-bold silver-gradient mb-4 italic text-white">Bリーグ</h3>
-                        <p class="text-xs text-gray-400 leading-relaxed mb-10">実力者がひしめく中堅階層。昇格と降格が常に交差する、最も過酷なサバイバル・ゾーン。</p>
-                        <div class="h-[1px] w-full divider-silver mb-8"></div>
+                        <p class="text-xs text-gray-400 leading-relaxed mb-6">実力者がひしめく中堅階層。昇格と降格が常に交差する、最も過酷なサバイバル・ゾーン。</p>
+                        <div class="h-[1px] w-full divider-silver mb-6"></div>
+                    </div>
+                    <div class="mb-2">
+                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-3 border-b border-silver-20 pb-2 text-silver">昇降格ルール</h4>
+                        <div class="rounded-sm border border-silver/20 bg-white/5 px-4 py-4">
+                            <p class="text-[11px] text-gray-300 leading-loose">
+                                <span class="text-white font-bold">上位 3 名</span> A リーグへ昇格<br>
+                                <span class="text-white font-bold">下位 8 名</span> C リーグへ降格
+                            </p>
+                        </div>
                     </div>
                     <div>
-                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-5 border-b border-silver-20 pb-2 text-silver">所属選手</h4>
+                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-3 border-b border-silver-20 pb-2 text-silver">所属選手</h4>
                         <div class="grid grid-cols-2 gap-2 text-[11px]">
                             <span class="border border-white/10 bg-white/5 px-3 py-2 text-white">いっせ</span>
                             <span class="border border-white/10 bg-white/5 px-3 py-2 text-white">かいる</span>
@@ -275,18 +320,27 @@
                 </div>
 
                 <!-- C League (Bronze) -->
-                <div class="jp-card p-10 bg-black reveal flex flex-col gap-8 delay-100 border-bronze">
+                <div class="jp-card p-8 lg:p-6 bg-black reveal flex flex-col gap-6 delay-100 border-bronze">
                     <div>
-                        <div class="flex justify-between items-start mb-8">
+                        <div class="flex justify-between items-start mb-6">
                             <span class="font-black text-[10px] tracking-widest uppercase text-bronze">Third Tier</span>
                             <span class="text-[9px] text-bronze">登竜門</span>
                         </div>
                         <h3 class="text-2xl font-serif font-bold bronze-gradient mb-4 italic">Cリーグ</h3>
-                        <p class="text-xs text-gray-400 leading-relaxed mb-10">鳳凰への登竜門。シーズン1の結果を受けてこの階層に配属されたプレイヤーたちが、次なるBリーグ昇格を目指します。</p>
-                        <div class="h-[1px] w-full divider-bronze mb-8"></div>
+                        <p class="text-xs text-gray-400 leading-relaxed mb-6">B 昇格を目指す登竜門。Season 3 からは新設の D リーグからの昇格者も合流し、上下双方から競争が生まれる中間層。</p>
+                        <div class="h-[1px] w-full divider-bronze mb-6"></div>
+                    </div>
+                    <div class="mb-2">
+                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-3 border-b border-bronze-30 pb-2 text-bronze">昇降格ルール</h4>
+                        <div class="rounded-sm border border-bronze/30 bg-white/5 px-4 py-4">
+                            <p class="text-[11px] text-gray-300 leading-loose">
+                                <span class="text-white font-bold">上位 30%</span> B リーグへ昇格<br>
+                                <span class="text-white font-bold">下位 20%</span> D リーグへ降格
+                            </p>
+                        </div>
                     </div>
                     <div>
-                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-5 border-b border-bronze-30 pb-2 text-bronze">所属選手</h4>
+                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-3 border-b border-bronze-30 pb-2 text-bronze">所属選手</h4>
                         <div class="grid grid-cols-2 gap-2 text-[11px]">
                             <span class="border border-white/10 bg-white/5 px-3 py-2 text-white">揚げもっちー２</span>
                             <span class="border border-white/10 bg-white/5 px-3 py-2 text-white">イナズマKすけ</span>
@@ -325,6 +379,40 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- D League (Iron) -->
+                <div class="jp-card p-8 lg:p-6 bg-black reveal flex flex-col gap-6 delay-100 border-iron">
+                    <div>
+                        <div class="flex justify-between items-start mb-6">
+                            <span class="font-black text-[10px] tracking-widest uppercase text-iron">Fourth Tier</span>
+                            <span class="text-[9px] text-iron">門出</span>
+                        </div>
+                        <h3 class="text-2xl font-serif font-bold iron-gradient mb-4 italic">Dリーグ</h3>
+                        <p class="text-xs text-gray-400 leading-relaxed mb-6">Season 3 から新設された新規参加者のスタート地点。実戦の中で評価を積み上げ、C リーグ昇格を目指す層。</p>
+                        <div class="h-[1px] w-full divider-iron mb-6"></div>
+                    </div>
+                    <div class="mb-2">
+                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-3 border-b border-iron-30 pb-2 text-iron">昇降格ルール</h4>
+                        <div class="rounded-sm border border-iron/30 bg-white/5 px-4 py-4">
+                            <p class="text-[11px] text-gray-300 leading-loose">
+                                <span class="text-white font-bold">上位 50%</span> C リーグへ昇格<br>
+                                <span class="text-white font-bold">下位 50%</span> 据置
+                            </p>
+                        </div>
+                    </div>
+                    <div>
+                        <h4 class="text-[9px] font-bold tracking-[0.2em] mb-3 border-b border-iron-30 pb-2 text-iron">所属選手</h4>
+                        <div class="grid grid-cols-2 gap-2 text-[11px]">
+                            <!-- 運営追加予定 -->
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mt-12 text-center reveal delay-200">
+                <p class="text-[11px] text-gray-500 italic leading-loose">
+                    ※ Season 3 におけるリーグは「評価区分」です。全プレイヤーが同卓で混在して対戦し、Season 終了時の総獲得 BB 数によって所属が決定されます。
+                </p>
             </div>
         </div>
     </section>
@@ -344,6 +432,10 @@
                     </h4>
                     <div class="bg-white/5 p-6 border border-white/5 rounded flex-grow">
                         <ul class="text-xs space-y-5 text-gray-400">
+                            <li class="flex justify-between border-b border-white/5 pb-2">
+                                <span class="font-bold">期間</span>
+                                <span class="text-white font-serif">6/8 — 7/27 / 全 8 節</span>
+                            </li>
                             <li class="flex justify-between border-b border-white/5 pb-2">
                                 <span class="font-bold">開催日</span>
                                 <span class="text-white">毎週月曜日</span>
@@ -366,11 +458,16 @@
                     </h4>
                     <div class="bg-white/5 p-6 border border-white/5 rounded flex-grow">
                         <div class="space-y-4">
-                            <div class="flex items-center gap-3">
+                            <div class="flex flex-wrap items-center gap-2">
                                 <span class="text-[10px] bg-gold/20 text-gold px-2 py-0.5 rounded font-black">NLH</span>
                                 <span class="text-[10px] bg-white/10 text-white px-2 py-0.5 rounded font-black uppercase">6-Max 限定</span>
+                                <span class="text-[10px] bg-white/10 text-white px-2 py-0.5 rounded font-black uppercase">SSpoker</span>
                             </div>
                             <ul class="text-xs space-y-3 text-gray-400">
+                                <li class="flex items-start gap-2">
+                                    <i class="fas fa-check text-gold text-[10px] mt-1"></i>
+                                    <span>プラットフォーム：<span class="text-white font-bold">Seeker Start poker (SSpoker)</span></span>
+                                </li>
                                 <li class="flex items-start gap-2">
                                     <i class="fas fa-check text-gold text-[10px] mt-1"></i>
                                     <span><span class="text-white font-bold">fastfold形式</span> を採用</span>
@@ -410,10 +507,63 @@
                                     <i class="fas fa-exclamation-triangle"></i> スタック運用ルール
                                 </h5>
                                 <p class="text-[10px] text-gray-400 leading-relaxed">
-                                    毎ハンド、全プレイヤーが <span class="text-white font-bold">100BB</span> からスタートする固定運用です。
+                                    毎ハンド、全プレイヤーが <span class="text-white font-bold">100BB</span> からスタートする固定運用です。<br>
+                                    超過分は <span class="text-white font-bold">「確定利益」</span> として Season 総獲得 BB に反映されます。
                                 </p>
                             </div>
                         </div>
+                    </div>
+                </div>
+
+                <!-- 04 成績評価 -->
+                <div class="reveal flex flex-col delay-300">
+                    <h4 class="text-gold font-serif font-bold text-lg mb-6 flex items-center gap-4">
+                        <span class="text-xs opacity-30">04</span> 成績評価
+                    </h4>
+                    <div class="bg-white/5 p-6 border border-white/5 rounded flex-grow">
+                        <ul class="text-xs space-y-4 text-gray-400">
+                            <li class="flex justify-between border-b border-white/5 pb-3">
+                                <span class="font-bold">順位決定</span>
+                                <span class="text-white font-serif">Season 総獲得 BB 数</span>
+                            </li>
+                            <li class="flex justify-between border-b border-white/5 pb-3">
+                                <span class="font-bold">タイブレーク</span>
+                                <span class="text-white">総ハンド数</span>
+                            </li>
+                            <li class="flex justify-between border-b border-white/5 pb-3">
+                                <span class="font-bold">公式成績</span>
+                                <span class="text-white font-serif">1,000 ハンド以上</span>
+                            </li>
+                            <li class="text-[10px] text-gray-500 leading-relaxed italic pt-1">
+                                ※ 1,000 ハンド未満は参考記録扱い。B 以上の所属は 1 ランク強制降格、D は据置となります。
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
+                <!-- 05 禁止行為 -->
+                <div class="reveal flex flex-col delay-300">
+                    <h4 class="text-gold font-serif font-bold text-lg mb-6 flex items-center gap-4">
+                        <span class="text-xs opacity-30">05</span> 禁止行為
+                    </h4>
+                    <div class="bg-white/5 p-6 border border-white/5 rounded flex-grow">
+                        <ul class="text-xs space-y-3 text-gray-400">
+                            <li class="flex items-start gap-2">
+                                <i class="fas fa-ban text-red-400 text-[10px] mt-1"></i>
+                                <span class="text-white font-bold">共謀</span>
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <i class="fas fa-ban text-red-400 text-[10px] mt-1"></i>
+                                <span class="text-white font-bold">チップダンピング</span>
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <i class="fas fa-ban text-red-400 text-[10px] mt-1"></i>
+                                <span class="text-white font-bold">複数アカウントの使用</span>
+                            </li>
+                            <li class="text-[10px] text-gray-500 leading-relaxed italic pt-2">
+                                ※ 全ハンドのログは成績集計のため記録され、配信・広報で公開される場合があります。
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>
@@ -501,7 +651,7 @@
                     </button>
                     <div class="faq-answer">
                         <div class="px-8 pb-8 text-gray-400 text-xs md:text-sm leading-loose">
-                            もちろんです。技量は実戦と学習の中で磨かれるものです。Cリーグは広く門戸を開いておりますので、向上心のあるプレイヤーを歓迎します。
+                            もちろんです。技量は実戦と学習の中で磨かれるものです。C・D リーグは広く門戸を開いておりますので、向上心のあるプレイヤーを歓迎します。
                         </div>
                     </div>
                 </div>
@@ -512,7 +662,29 @@
                     </button>
                     <div class="faq-answer">
                         <div class="px-8 pb-8 text-gray-400 text-xs md:text-sm leading-loose">
-                            Poker Now等のログを運営が抽出し、公式スプレッドシートおよびDiscord上で公開します。透明性を担保し、全ハンドの整合性をチェックしています。
+                            Seeker Start poker (SSpoker) のログを運営が抽出し、公式スプレッドシートおよび Discord 上で公開します。透明性を担保し、全ハンドの整合性をチェックしています。
+                        </div>
+                    </div>
+                </div>
+                <div class="faq-item reveal bg-white/5 border border-white/10 rounded overflow-hidden delay-300">
+                    <button class="w-full p-6 md:p-8 flex justify-between items-center text-left focus:outline-none transition-colors hover:bg-white/10" onclick="toggleFaq(this)">
+                        <span class="font-serif font-bold text-white text-sm md:text-base tracking-wider">途中参加・途中退室は可能ですか？</span>
+                        <i class="fas fa-chevron-down text-gold transition-transform duration-300"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <div class="px-8 pb-8 text-gray-400 text-xs md:text-sm leading-loose">
+                            可能です。開催時間内であればいつでも自由に入退室いただけます。また、Season 開幕後の途中参加も歓迎しています。
+                        </div>
+                    </div>
+                </div>
+                <div class="faq-item reveal bg-white/5 border border-white/10 rounded overflow-hidden delay-300">
+                    <button class="w-full p-6 md:p-8 flex justify-between items-center text-left focus:outline-none transition-colors hover:bg-white/10" onclick="toggleFaq(this)">
+                        <span class="font-serif font-bold text-white text-sm md:text-base tracking-wider">参加するにはどうすればよいですか？</span>
+                        <i class="fas fa-chevron-down text-gold transition-transform duration-300"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <div class="px-8 pb-8 text-gray-400 text-xs md:text-sm leading-loose">
+                            ページ末尾の参戦ボタンから、Google または Discord アカウントの連携でログインしてご参加ください。所要時間は約 5 分です。
                         </div>
                     </div>
                 </div>
@@ -535,14 +707,12 @@
                 歴史の<span class="gold-gradient">目撃者</span>ではなく、<br><span class="text-white">当事者</span>となれ。
             </h2>
             <div class="w-16 h-[1px] bg-gold mx-auto mb-16"></div>
-            <a href="https://x.com/seekerstart" target="_blank" class="inline-block group relative">
-                <div class="absolute inset-0 bg-gold translate-x-1 translate-y-1 group-hover:translate-x-0 group-hover:translate-y-0 transition duration-300"></div>
-                <div class="relative bg-white text-black px-12 md:px-20 py-5 md:py-6 font-black tracking-[0.5em] text-xs md:text-sm border border-black uppercase">
-                    公式Xより参戦を申し込む
-                </div>
+            <a href="https://fast-table-production.up.railway.app/" target="_blank" rel="noopener" class="hero-cta text-sm md:text-base">
+                <i class="fas fa-feather hero-cta-icon"></i>
+                <span>Season 3 に参戦する</span>
             </a>
-            <p class="text-[10px] text-gray-500 mt-6 tracking-widest">
-                ※参加希望者は鳳凰戦参加とDMをお願いします。
+            <p class="text-[10px] text-gray-500 mt-6 tracking-widest leading-relaxed">
+                ※ Google または Discord アカウントの連携で申込可能（所要約 5 分）。途中参加・退室自由。
             </p>
         </div>
     </section>


### PR DESCRIPTION
## Summary
コラム（https://www.seekerstart.com/columns/poker-houou-season3-open）の Season 3 開幕情報にトップページ `index.html` を合わせて更新しました。

- **シーズン情報**: Season 3（6/8〜7/27 全8節）へ差し替え、開催スケジュール一覧を追加
- **リーグ構成**: A/B/C/D の4リーグ制へ拡張。各リーグに昇降格ルールを明記し、新設の D リーグカードを追加（B/C の所属選手リストは維持）
- **ルール**: 「成績評価」「禁止行為」のカードを追加、プラットフォーム表記を Poker Now → Seeker Start poker (SSpoker) に更新、スタック運用ルールに確定利益の記載を追記
- **FAQ**: 「途中参加・退室」「参加方法」を追加、SSpoker 表記へ更新
- **CTA**: ヒーロー上部に参戦ボタンを新設し、ヒーロー／下部の2箇所をゴールド基調の新デザイン（羽根アイコン＋グロー＋シャイン）に統一。リンク先を参加フォーム（https://fast-table-production.up.railway.app/）へ直結
- **整理**: ヒーローの「最新シーズン」「ランクシステム」ボックスリンクを削除

## 補足（別タスク）
- `images/season3-guide.png` 未用意のため、暫定で `season2-guide.png` にフォールバック
- `config/seasons.json` の S3 定義追加、`season-rules-s3.html` の新規作成は別途対応予定

## Test plan
- [ ] デスクトップ（1280px〜）で Season セクション・4リーグカード・ルール5カードの表示崩れがないこと
- [ ] モバイル（375px）で CTA ボタンが1行に収まり、レイアウトが崩れないこと
- [ ] 上下2箇所の CTA ボタンが参加フォームへ別タブで遷移すること
- [ ] ページ内アンカー・フッターリンクが従来どおり動作すること
- [ ] ブラウザコンソールにエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)