### PR TITLE
シーズン3制度ページ（season-rules-s3.html）を追加

### DIFF
--- a/config/season_rule_pages.json
+++ b/config/season_rule_pages.json
@@ -1,6 +1,79 @@
 {
-  "current_slug": "s2",
+  "current_slug": "s3",
   "pages": [
+    {
+      "slug": "s3",
+      "season_label": "Season 03",
+      "title": "シーズン3条件",
+      "description": "",
+      "period_label": "2026.06.08 - 2026.07.27",
+      "hero_image": "images/houoh_kaimaku.png",
+      "thumbnail_image": "images/houoh_kaimaku.png",
+      "summary": "外部参加を解禁し、A/B/C/D の4リーグ制へ移行。リーグは「評価区分」として全プレイヤーが同卓で混在し、Season 総獲得 BB 数で順位を決定します。規定ハンド数は1000ハンドです。",
+      "overview": "シーズン3では、最高位 A リーグの本格運用を開始し、新たに D リーグを新設した4リーグ制へ移行します。\nリーグは所属クラスではなく「評価区分」として位置付けられ、全リーグのプレイヤーが同卓（NLH / 6-max / fastfold）で混在して対戦します。\n順位は Season を通じた総獲得 BB 数で決定し、同数の場合は総ハンド数が多いプレイヤーを上位とします。\n各回 100BB のバイインで運用し、超過分は「確定利益」として Season 総獲得 BB に反映されます。\nなお、3 Season 連続で A リーグに所属した選手には最高位「鳳凰位」が付与されます。",
+      "promotion_heading": "昇格条件（B・C・Dリーグ）",
+      "relegation_heading": "降格条件（A・B・Cリーグ）",
+      "promotion_blocks": [
+        {
+          "title": "BリーグからAリーグへ昇格",
+          "accent": "上位3名 / Aリーグへ昇格"
+        },
+        {
+          "title": "CリーグからBリーグへ昇格",
+          "accent": "上位30% / Bリーグへ昇格"
+        },
+        {
+          "title": "DリーグからCリーグへ昇格",
+          "accent": "上位50% / Cリーグへ昇格"
+        }
+      ],
+      "relegation_blocks": [
+        {
+          "title": "Aリーグ下位帯の扱い",
+          "accent": "下位1名 / Bリーグへ降格",
+          "body": "上位3名はAリーグに残留します。"
+        },
+        {
+          "title": "Bリーグ下位帯の扱い",
+          "accent": "下位8名 / Cリーグへ降格"
+        },
+        {
+          "title": "Cリーグ下位帯の扱い",
+          "accent": "下位20% / Dリーグへ降格"
+        },
+        {
+          "title": "Dリーグ下位帯の扱い",
+          "accent": "下位50% / 据置（降格なし）"
+        }
+      ],
+      "extra_rules": [
+        {
+          "title": "順位決定とタイブレーク",
+          "body": "順位は Season 総獲得 BB 数で決定します。同一 BB 数の場合は、総ハンド数が多いプレイヤーを上位とします。"
+        },
+        {
+          "title": "公式成績の認定基準",
+          "body": "規定ハンド数は1000ハンドです。1000ハンドに満たない場合は参考記録扱いとなり、B リーグ以上に所属する場合は次シーズン1ランク強制降格、D リーグは据置となります。"
+        },
+        {
+          "title": "禁止行為とログの取り扱い",
+          "body": "共謀、チップダンピング、複数アカウントの使用を禁止します。全ハンドのログは成績集計のため記録され、配信・広報で公開される場合があります。"
+        }
+      ],
+      "schedule": [
+        { "week_label": "第1節", "date_label": "2026/06/08", "time_label": "20:00 - 23:00" },
+        { "week_label": "第2節", "date_label": "2026/06/15", "time_label": "20:00 - 23:00" },
+        { "week_label": "第3節", "date_label": "2026/06/22", "time_label": "20:00 - 23:00" },
+        { "week_label": "第4節", "date_label": "2026/06/29", "time_label": "20:00 - 23:00" },
+        { "week_label": "第5節", "date_label": "2026/07/06", "time_label": "20:00 - 23:00" },
+        { "week_label": "第6節", "date_label": "2026/07/13", "time_label": "20:00 - 23:00" },
+        { "week_label": "第7節", "date_label": "2026/07/20", "time_label": "20:00 - 23:00" },
+        { "week_label": "第8節", "date_label": "2026/07/27", "time_label": "20:00 - 23:00" }
+      ],
+      "diagram_image": "images/houoh_kaimaku.png",
+      "diagram_caption": "",
+      "stats_link": "/houou/season_stats.html"
+    },
     {
       "slug": "s2",
       "season_label": "Season 02",

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
                         最新制度と過去シーズンの条件差分は、専用の制度ページで確認できます。
                     </p>
                     <div class="flex flex-col sm:flex-row gap-3">
-                        <a href="/houou/season-rules-s2.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                        <a href="/houou/season-rules-s3.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                             今季の制度を見る <i class="fas fa-arrow-right"></i>
                         </a>
                         <a href="/houou/season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-4 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">
@@ -584,7 +584,7 @@
                         </p>
                     </div>
                     <div class="flex flex-col sm:flex-row justify-center gap-3 pt-2">
-                        <a href="/houou/season-rules-s2.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
+                        <a href="/houou/season-rules-s3.html" class="inline-flex items-center justify-center gap-2 border border-gold/40 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-gold hover:text-white hover:border-gold transition-all duration-300">
                             今季の制度ページ <i class="fas fa-arrow-right"></i>
                         </a>
                         <a href="/houou/season-rules.html" class="inline-flex items-center justify-center gap-2 border border-white/10 px-5 py-3 text-[11px] font-black tracking-[0.2em] uppercase text-white/80 hover:text-white hover:border-white/40 transition-all duration-300">

--- a/season-rules-s3.html
+++ b/season-rules-s3.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ja" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="images/favicon.png" type="image/png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>シーズン3条件 | ポーカー鳳凰戦</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="canonical" href="https://www.seekerstart.com/houou/season-rules-s3.html">
+    <meta name="description" content="ポーカー鳳凰戦シーズン3の条件ページです。A/B/C/D 4リーグ制の昇格・降格・認定条件と開催スケジュールを確認できます。">
+    <script>if(location.hostname==='seekerstart-hp.vercel.app')location.replace('https://www.seekerstart.com/houou/'+location.pathname.slice(1)+location.search+location.hash);</script>
+</head>
+<body class="antialiased" data-page-mode="season-rules-detail" data-season-rule-slug="s3">
+
+    <div id="site-header"></div>
+
+    <main class="pt-32 pb-24 min-h-screen">
+        <div class="container mx-auto px-6 max-w-6xl">
+            <div id="season-rule-detail"></div>
+        </div>
+    </main>
+
+    <footer class="bg-[#050505] py-12 border-t border-white/5">
+        <div class="container mx-auto px-6 text-center">
+            <div class="flex items-center justify-center gap-4 mb-6">
+                <img src="images/SeekerStart_logo.png" alt="Logo" class="h-6 w-auto" onerror="this.src='https://via.placeholder.com/80x30/111/d4af37?text=Logo'">
+                <span class="text-base font-serif font-black tracking-[0.2em] text-white">ポーカー鳳凰戦</span>
+            </div>
+            <p class="text-gray-600 text-[10px] mb-6">
+                Seeker Start 運営による公式シーズン制度ページ
+            </p>
+            <div class="text-[9px] text-gray-700 font-bold uppercase tracking-[0.4em]">
+                &copy; 2026 POKER HOUOU LEAGUE. ALL RIGHTS RESERVED.
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/header.js"></script>
+    <script src="js/season-rules.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
シーズン制度ページ群に Season 3 版を追加しました。内容はコラム（https://www.seekerstart.com/columns/poker-houou-season3-open）の S3 情報に準拠しています。

- **`season-rules-s3.html` を新規作成**: `season-rules-s2.html` をベースに `title` / `canonical` / `data-season-rule-slug="s3"` / meta description を S3 用に変更
- **`config/season_rule_pages.json` を更新**: `pages` 先頭に S3 エントリを追加し、`current_slug` を `s3` に変更
  - A/B/C/D 4リーグ制の昇格条件（B→A 上位3名 / C→B 上位30% / D→C 上位50%）
  - 降格条件（A→B 下位1名 / B→C 下位8名 / C→D 下位20% / D 据置）
  - 順位決定（Season 総獲得 BB・タイブレークは総ハンド数）、公式成績認定（1000ハンド）、禁止行為
  - 全8節の開催スケジュール（6/8〜7/27）
- **`index.html` の制度リンク2箇所**を `season-rules-s3.html` に差し替え

制度ページは `js/season-rules.js` による動的レンダリング方式のため、**JS / CSS の変更は不要**です。

## 補足（別タスク）
- ヒーロー/図解画像は暫定で `images/houoh_kaimaku.png` を使用。`images/season3-guide.png` 用意後に JSON を差し替え予定
- `config/seasons.json` への S3 定義追加（ランキング/統計機能用）は別途対応

## Test plan
- [ ] `/season-rules-s3.html`: ヒーロー「Season 03 / 2026.06.08 - 2026.07.27」、昇格3カード・降格4カード・補足3カード・全8節スケジュールが表示される
- [ ] `/season-rules.html`: S3 が「Current」特集表示され、カード順が S3 → S2 → S1
- [ ] `/`（トップ）の「今季の制度を見る」「今季の制度ページ」が season-rules-s3.html に遷移する
- [ ] 前シーズン切替リンクが Season 02 を指す
- [ ] ブラウザコンソールに JS エラー（JSON パースエラー含む）が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)