### PR TITLE
本番ドメインの noindex を解除し検索インデックスを許可

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,13 @@
   "headers": [
     {
       "source": "/(.*)",
+      "has": [{ "type": "host", "value": "seekerstart-hp.vercel.app" }],
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+      ]
+    },
+    {
+      "source": "/all_stats_internal.html",
       "headers": [
         { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
       ]


### PR DESCRIPTION
## Summary
鳳凰戦サイトを検索インデックス可能にするための第一段階（本リポ側の対応）です。

これまで `vercel.json` が全パスに `X-Robots-Tag: noindex, nofollow` を付与しており、プロキシ経由で公開URL `www.seekerstart.com/houou/*` にもこのヘッダーが乗ってインデックスを妨げていました（実測確認済み）。

- `X-Robots-Tag` を **host 条件付き**に変更
  - `seekerstart-hp.vercel.app`（重複コンテンツの素ドメイン）→ noindex を**維持**（当初の重複防止目的を保持）
  - `www.seekerstart.com/houou/*` → noindex を**解除**（インデックス対象に）
- 内部用 `all_stats_internal.html` は host を問わず noindex を維持（既存の `<meta name="robots">` と二重防御）

## ⚠️ デプロイ後に必須の検証
プロキシが上流へ渡す Host ヘッダー次第で host 条件の効き方が変わるため、マージ・デプロイ後に実測してください:

\`\`\`
# www は noindex が出ないこと（解禁成功）
curl -sI https://www.seekerstart.com/houou/index.html | grep -i x-robots-tag
# vercel.app は noindex が出ること（重複防止維持）
curl -sI https://seekerstart-hp.vercel.app/ | grep -i x-robots-tag
\`\`\`

想定通りにならない場合は、`X-Robots-Tag` を完全削除し canonical 依存へフォールバックします。

## 本PRだけでは完結しない（親サイト側の別対応が必要）
検索インデックスには、別プロジェクト `www.seekerstart.com` 側の対応も必要です（本PR対象外）:
- **`/houou/`（末尾スラッシュ）が 410 Gone** を返す問題の解消（canonical のトップが 410 のままだとインデックス不可）※最優先
- `sitemap.xml` への `/houou/` 配下URL追加
- Google Search Console での登録・インデックス申請

## Test plan
- [ ] `vercel.json` が妥当な JSON（CI/ローカルで確認済み）
- [ ] デプロイ後: `www.seekerstart.com/houou/index.html` に noindex が出ない
- [ ] デプロイ後: `seekerstart-hp.vercel.app/` に noindex が出る
- [ ] デプロイ後: `all_stats_internal.html` は両ドメインで noindex が出る
- [ ] 親サイト側の 410・sitemap・Search Console 対応（別タスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)