### PR TITLE
noindex を全削除し canonical 依存に切替（host条件方式が本番で無効のため）

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,6 @@
 {
   "headers": [
     {
-      "source": "/(.*)",
-      "has": [{ "type": "host", "value": "seekerstart-hp.vercel.app" }],
-      "headers": [
-        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
-      ]
-    },
-    {
       "source": "/all_stats_internal.html",
       "headers": [
         { "key": "X-Robots-Tag", "value": "noindex, nofollow" }


### PR DESCRIPTION
## Summary
PR #62（host 条件で noindex を出し分ける方式）をデプロイ後に実測したところ、**本番 `www.seekerstart.com/houou/*` の noindex が外れませんでした**。

### 原因（実測で確定）
Vercel マルチゾーン構成では、親サイト `www.seekerstart.com` が当プロジェクトを `seekerstart-hp.vercel.app` として **server-side で取得（プロキシ）** します。そのため www 経由のアクセスでも当プロジェクトには `Host: seekerstart-hp.vercel.app` として届き、`has host` 条件が常にマッチして noindex が残っていました（デプロイは success 済みで反映ラグではないことを確認）。

### 対応（プランで事前承認済みのフォールバック）
- `X-Robots-Tag` のグローバル付与を**削除** → `www.seekerstart.com/houou/*` がインデックス対象に。
- `seekerstart-hp.vercel.app` の重複コンテンツは、全ページに既存の **canonical タグ（www を指す）** で正規化（Google はクロスドメイン canonical を尊重し www に集約）。
- 内部用 `all_stats_internal.html` は **パス限定ヘッダー＋ `<meta name="robots">`** でホスト問わず noindex を維持。

## デプロイ後の検証
\`\`\`
# www は noindex が出ないこと（解禁成功）
curl -sI https://www.seekerstart.com/houou/index.html | grep -i x-robots-tag   # ← 出なければOK
# 内部ページは noindex 維持
curl -sI https://www.seekerstart.com/houou/all_stats_internal.html | grep -i x-robots-tag
\`\`\`

## まだ完結しない（親サイト側の対応が必要）
- **`/houou/`（末尾スラッシュ）の 410 Gone 解消**（canonical のトップが 410 のままだとインデックス不可）※最優先
- `sitemap.xml` への `/houou/` 配下URL追加
- Google Search Console 登録・インデックス申請

## Test plan
- [ ] `vercel.json` が妥当な JSON（確認済み）
- [ ] デプロイ後: `www.seekerstart.com/houou/index.html` に noindex が出ない
- [ ] デプロイ後: `all_stats_internal.html` は noindex 維持
- [ ] 親サイト側 410・sitemap・Search Console（別タスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)