### PR TITLE
feat: ワークフローでPR自動マージを追加

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -77,7 +77,7 @@ jobs:
           git add -A
           git diff --cached --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
 
-      - name: Create branch, commit, and open PR
+      - name: Create branch, commit, open PR, and merge
         if: steps.git-check.outputs.changes == 'true' && inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -94,3 +94,4 @@ jobs:
             --body "GitHub Actions による自動更新" \
             --base main \
             --head "$BRANCH"
+          gh pr merge "$BRANCH" --merge --delete-branch


### PR DESCRIPTION
## Summary
- ランキング更新ワークフローで、PR作成後に `gh pr merge --merge --delete-branch` を実行し、自動マージ＋ブランチ削除まで完了するように変更
- これにより cron 起動 → DB取得 → 計算 → PR作成 → マージ → Vercel デプロイ が全自動で完了する

## Test plan
- [ ] workflow_dispatch で dry_run=false で手動実行し、PR作成→マージ→ブランチ削除まで完了することを確認
- [ ] マージ後に Vercel デプロイが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)